### PR TITLE
RDKEMW-876 : Send MigrationReady value to Xconf server as part of

### DIFF
--- a/src/device_status_helper.c
+++ b/src/device_status_helper.c
@@ -810,6 +810,17 @@ size_t createJsonString( char *pPostFieldOut, size_t szPostFieldOut )
         remainlen = szPostFieldOut - totlen;
         totlen += snprintf( (pTmpPost + totlen), remainlen, "experience=%s", tmpbuf );
     }
+    len = GetMigrationReady( tmpbuf, sizeof(tmpbuf) );
+    if( len )
+    {
+        if( totlen )
+        {
+            *(pTmpPost + totlen) = '&';
+            ++totlen;
+        }
+        remainlen = szPostFieldOut - totlen;
+        totlen += snprintf( (pTmpPost + totlen), remainlen, "migrationReady=%s", tmpbuf );
+    }
     len = GetSerialNum( tmpbuf, sizeof(tmpbuf) );
     if( len )
     {

--- a/src/deviceutils/device_api.c
+++ b/src/deviceutils/device_api.c
@@ -691,6 +691,41 @@ size_t GetExperience( char *pExperience, size_t szBufSize )
     return i;
 }
 
+/* function GetMigrationReady - gets the migration readiness status.
+
+        Usage: size_t GetMigrationReady <char *pMRComponents> <size_t szBufSize>
+
+            pMRComponents - pointer to a char buffer to store the output string.
+
+            szBufSize - the size of the character buffer in argument 1.
+
+            RETURN - number of characters copied to the output buffer.
+*/
+size_t GetMigrationReady( char *pMRComponents, size_t szBufSize )
+{
+    size_t i = 0;
+
+    if( pMRComponents != NULL )
+    {
+        i = read_RFCProperty( "MigrationReady", MR_ID, pMRComponents, szBufSize );
+        if( i == READ_RFC_FAILURE )
+        {
+            i = snprintf( pMRComponents, szBufSize, "Unknown" );
+            SWLOG_ERROR( "GetMigrationReady: read_RFCProperty() failed Status %d\n", i );
+        }
+        else
+        {
+            i = strnlen( pMRComponents, szBufSize );
+//            SWLOG_INFO( "GetMigrationReady: MRComponents = %s\n", pMRComponents );
+        }
+    }
+    else
+    {
+        SWLOG_ERROR( "GetMigrationReady: Error, input argument NULL\n" );
+    }
+    return i;
+}
+
 /* function GetAccountID - gets the account ID of the device.
  
         Usage: size_t GetAccountID <char *pAccountID> <size_t szBufSize>

--- a/src/deviceutils/device_api.h
+++ b/src/deviceutils/device_api.h
@@ -100,6 +100,8 @@ typedef enum {
 #define BOOTSTRAPURL        "BsXconfUrl"
 #define BOOTSTRAPDEFAULT    NO_URL
 
+#define MR_ID               "Device.DeviceInfo.MigrationPreparer.MigrationReady"
+
 /* function GetServerUrlFile - scans a file for a URL. 
         Usage: size_t GetServerUrlFile <char *pServUrl> <size_t szBufSize> <char *pFileName>
  
@@ -238,6 +240,17 @@ size_t GetSerialNum( char *pSerialNum, size_t szBufSize);
 // TODO: GetExperience must be implemented correctly
 size_t GetExperience(char *pExperience, size_t szBufSize);
 
+/* function GetMigrationReady - gets the migration readiness status.
+
+       Usage: size_t GetMigrationReady <char *pMRComponents> <size_t szBufSize>
+
+            pMRComponents - pointer to a char buffer to store the output string.
+
+            szBufSize - the size of the character buffer in argument 1.
+
+            RETURN - number of characters copied to the output buffer.
+*/
+size_t GetMigrationReady(char *pMRComponents, size_t szBufSize);
 
 /* function GetAccountID - gets the account ID of the device.
  


### PR DESCRIPTION
maintenance reboot

Reason for change : Send MigrationReady value to Xconf server as part of maintenance reboot.

Test Procedure: 1.To check whether componentreadiness is sent to xconf server.

Risks: Low