### PR TITLE
RDK-54955: Make rdkfwupdater buildable in docker container (#14)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,11 +20,7 @@ AM_CFLAGS = $(TRACE_CFLAGS)
 AM_CFLAGS += -Wall -Werror $(cjson_CFLAGS) $(curl_CFLAGS) $(CFLAGS)
 AM_LDFLAGS = -L$(PKG_CONFIG_SYSROOT_DIR)/$(libdir)
 AM_LDFLAGS += $(cjson_LIBS) $(curl_LIBS)
-AM_LDFLAGS += -lrfcapi -ltelemetry_msgsender -lt2utils -lIARMBus -lrdkloggers -ldwnlutil -lfwutils -lsecure_wrapper -lparsejson -lpthread
-if IS_LIBRDKCONFIG_ENABLED
-AM_CFLAGS += $(LIBRDKCONFIG_FLAG)
-AM_LDFLAGS += -lrdkconfig
-endif
+AM_LDFLAGS += -lrdkloggers -ldwnlutil -lfwutils -lsecure_wrapper -lparsejson -lpthread
 
 bin_PROGRAMS= rdkvfwupgrader
 bin_PROGRAMS+= testrdkvfwupgrader
@@ -85,3 +81,25 @@ testrdkvfwupgrader_include_HEADERS = \
     ${top_srcdir}/test/testiarmInterface.h
 
 testrdkvfwupgrader_includedir = ${includedir}
+
+
+if IS_TELEMETRY2_ENABLED
+rdkvfwupgrader_CFLAGS +=  $(T2_EVENT_FLAG)
+AM_LDFLAGS += -ltelemetry_msgsender -lt2utils
+endif
+
+if IS_LIBRFCAPI_ENABLED
+rdkvfwupgrader_CFLAGS += $(LIBRFCAPI_FLAG)
+AM_LDFLAGS += -lrfcapi
+endif
+
+if IS_IARMEVENT_ENABLED
+rdkvfwupgrader_CFLAGS += $(IARM_EVENT_FLAG)
+testrdkvfwupgrader_CFLAGS = $(IARM_EVENT_FLAG)
+AM_LDFLAGS += -lIARMBus
+endif
+
+if IS_LIBRDKCONFIG_ENABLED
+rdkvfwupgrader_CFLAGS += $(LIBRDKCONFIG_FLAG)
+AM_LDFLAGS += -lrdkconfig
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -73,6 +73,48 @@ AC_ARG_ENABLE([mountutils],
 AM_CONDITIONAL([IS_LIBRDKCONFIG_ENABLED], [test x$IS_LIBRDKCONFIG_ENABLED = xtrue])
 AC_SUBST(LIBRDKCONFIG_FLAG)
 
+AC_ARG_ENABLE([rfcapi],
+        AS_HELP_STRING([--enable-rfcapi],[enables rfcapi]),
+        [
+          case "${enableval}" in
+           yes) IS_LIBRFCAPI_ENABLED=true
+                LIBRFCAPI_FLAG=" -DRFC_API_ENABLED ";;
+           no)  IS_LIBRFCAPI_ENABLED=false ;;
+          *) AC_MSG_ERROR([bad value ${enableval} for --enable-rfcapi]) ;;
+           esac
+           ],
+        [echo "rfcapi is disabled"])
+AM_CONDITIONAL([IS_LIBRFCAPI_ENABLED], [test x$IS_LIBRFCAPI_ENABLED = xtrue])
+AC_SUBST(LIBRFCAPI_FLAG)
+
+AC_ARG_ENABLE([t2api],
+        AS_HELP_STRING([--enable-t2api],[enables telemetry]),
+        [
+          case "${enableval}" in
+           yes) IS_TELEMETRY2_ENABLED=true
+                T2_EVENT_FLAG=" -DT2_EVENT_ENABLED ";;
+           no)  IS_TELEMETRY2_ENABLED=false ;;
+          *) AC_MSG_ERROR([bad value ${enableval} for --enable-t2enable]) ;;
+           esac
+           ],
+        [echo "telemetry is disabled"])
+AM_CONDITIONAL([IS_TELEMETRY2_ENABLED], [test x$IS_TELEMETRY2_ENABLED = xtrue])
+AC_SUBST(T2_EVENT_FLAG)
+
+AC_ARG_ENABLE([iarmevent],
+        AS_HELP_STRING([--enable-iarmevent],[enables IARM event]),
+        [
+          case "${enableval}" in
+           yes) IS_IARMEVENT_ENABLED=true
+                IARM_EVENT_FLAG=" -DIARM_ENABLED ";;
+           no)  IS_IARMEVENT_ENABLED=false ;;
+          *) AC_MSG_ERROR([bad value ${enableval} for --enable-iarmevent]) ;;
+           esac
+           ],
+        [echo "iarm is disabled"])
+AM_CONDITIONAL([IS_IARMEVENT_ENABLED], [test x$IS_IARMEVENT_ENABLED = xtrue])
+AC_SUBST(IARM_EVENT_FLAG)
+
 PKG_CHECK_MODULES([cjson], [libcjson])
 PKG_CHECK_MODULES([curl], [libcurl])
 

--- a/cov_build.sh
+++ b/cov_build.sh
@@ -1,0 +1,28 @@
+WORKDIR=`pwd`
+export ROOT=/usr
+export INSTALL_DIR=${ROOT}/local
+mkdir -p $INSTALL_DIR
+cd $ROOT
+
+# Build common utilities
+cd /home
+git clone https://github.com/rdkcentral/common_utilities.git
+cd /home/common_utilities
+autoreconf -i
+./configure --prefix=${INSTALL_DIR} CFLAGS="-Wno-unused-result -Wno-format-truncation -Wno-error=format-security"
+make && make install
+
+#Build libsyswrapper
+cd /home
+git clone https://github.com/rdkcmf/rdk-libSyscallWrapper.git
+cd /home/rdk-libSyscallWrapper
+autoreconf -i
+./configure --prefix=${INSTALL_DIR}
+make
+make install
+
+#Build rdkfwupdater
+cd /home/rdkfwupdater
+autoreconf -i
+./configure --prefix=${INSTALL_DIR}
+make && make install

--- a/src/deviceutils/device_api.c
+++ b/src/deviceutils/device_api.c
@@ -878,7 +878,7 @@ size_t GetBuildType( char *pBuildType, size_t szBufSize, BUILDTYPE *peBuildTypeO
 
         if( *pBuildType == 0 && pOut != NULL )
         {
-            i = snprintf( pBuildType, szBufSize, pOut );
+            i = snprintf( pBuildType, szBufSize, "%s", pOut );
         }
     }
     else

--- a/src/iarmInterface/iarmInterface.h
+++ b/src/iarmInterface/iarmInterface.h
@@ -19,6 +19,7 @@
 #ifndef VIDEO_IARMINTERFACE_IARMINTERFACE_H_
 #define VIDEO_IARMINTERFACE_IARMINTERFACE_H_
 
+#if defined(IARM_ENABLED)
 #ifndef GTEST_ENABLE
 #include "sysMgr.h"
 #include "libIARMCore.h"
@@ -72,6 +73,7 @@ typedef struct _IARM_BUS_SYSMgr_EventData_t{
 
 typedef char gchar;
 
+#endif
 #endif
 
 #define IARM_BUS_RDKVFWUPGRADER_MGR_NAME "RdkvFWupgrader"

--- a/src/include/rdkv_cdl.h
+++ b/src/include/rdkv_cdl.h
@@ -29,14 +29,11 @@
 #include <stdbool.h>
 
 #ifndef GTEST_ENABLE
+#ifdef T2_EVENT_ENABLED
 #include <telemetry_busmessage_sender.h>
-#include "libIBus.h"
-#include "libIBusDaemon.h"
-#include "sysMgr.h"
-#include "libIARMCore.h"
-#include "urlHelper.h"
-#include <glib.h>
+#endif
 #include <secure_wrapper.h>
+#include "urlHelper.h"
 #endif
 
 #include "mtlsUtils.h"

--- a/src/rdkv_main.c
+++ b/src/rdkv_main.c
@@ -251,6 +251,7 @@ void getPidStore(const char *device, const char *maint_window) {
  * @return : void
  * */
 void t2CountNotify(char *marker) {
+#ifdef T2_EVENT_ENABLED
     T2ERROR t2_ret = -1;
     if(marker != NULL) {
         t2_ret = t2_event_s(marker, "1");
@@ -258,10 +259,12 @@ void t2CountNotify(char *marker) {
     }else {
         SWLOG_INFO("t2CountNotify() marker is NULL\n");
     }
+#endif
 }
 
 void t2ValNotify( char *marker, char *val )
 {
+#ifdef T2_EVENT_ENABLED
     T2ERROR t2_ret;
 
     if( marker != NULL && val != NULL )
@@ -273,6 +276,7 @@ void t2ValNotify( char *marker, char *val )
     {
         SWLOG_INFO("t2CountNotify() Error: one or more input args is NULL\n");
     }
+#endif
 }
 
 // TODO: Use following function for all types of downloads when needed for telemetry v2 logs
@@ -417,7 +421,9 @@ int initialize(void) {
     int mode = 1;
     char post_data[] = "{\"jsonrpc\":\"2.0\",\"id\":\"3\",\"method\":\"org.rdk.MaintenanceManager.1.getMaintenanceMode\",\"params\":{}}";
 
+#ifdef T2_EVENT_ENABLED
     t2_init("rdkfwupgrader");
+#endif
  
     *cur_img_detail.cur_img_name = 0;
     *rfc_list.rfc_fw_upgrader = 0;
@@ -465,7 +471,9 @@ int initialize(void) {
  * @return: void
  * */
 void uninitialize(int fwDwnlStatus) {
+#ifdef T2_EVENT_ENABLED
     t2_uninit();
+#endif
     pthread_mutex_destroy(&mutuex_dwnl_state);
     pthread_mutex_destroy(&app_mode_status);
     term_event_handler();

--- a/test/testiarmInterface.c
+++ b/test/testiarmInterface.c
@@ -25,8 +25,7 @@
 
 #include "testiarmInterface.h"
 
-//#include "rdkv_cdl_log_wrapper.h"
-
+#if defined(IARM_ENABLED)
 void eventManagerTest(const char *cur_event_name, int app_mode) {
     if(cur_event_name == NULL) {
         printf("eventManager() failed due to NULL parameter\n");
@@ -62,14 +61,16 @@ void eventManagerTest(const char *cur_event_name, int app_mode) {
     IARM_Bus_Term();
     printf("%s : IARM_event_sender closing\n", __FUNCTION__);
 }
-
+#endif
 int main(int argc, char *argv[])
 {
    int app_mode = 0;
    if (argc == 2) {
        app_mode = atoi(argv[1]);
        printf("app mode = %d\n", app_mode);
+#if defined(IARM_ENABLED)
        eventManagerTest("RdkvFWupgrader", app_mode);
+#endif
    } else {
        printf("Invalid no of argument\nReq only 1 argument 1 or 0\n");
    }

--- a/test/testiarmInterface.h
+++ b/test/testiarmInterface.h
@@ -21,11 +21,13 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(IARM_ENABLED)
 #include "sysMgr.h"
 #include "libIARMCore.h"
 #include "libIBus.h"
 #include "libIBusDaemon.h"
 #include <glib.h>
+#endif
 //#ifdef EN_MAINTENANCE_MANAGER
 //#include "maintenanceMGR.h"
 //#endif

--- a/unittest/Makefile.am
+++ b/unittest/Makefile.am
@@ -21,7 +21,7 @@ AUTOMAKE_OPTIONS = subdir-objects
 bin_PROGRAMS = rdkfw_device_status_gtest rdkfw_deviceutils_gtest rdkfw_main_gtest rdkfw_interface_gtest
 
 # Define the include directories
-COMMON_CPPFLAGS = -std=c++11 -I/usr/include/cjson -I../src -I../src/cedmInterface -I../src/deviceutils/ -I../src/rfcInterface/ -I../src/iarmInterface/ -I../src/include/ -I./mocks/ -I./deviceutils/ -DGTEST_ENABLE -DGTEST_BASIC -DIARM_ENABLED -DRFC_API_ENABLED
+COMMON_CPPFLAGS = -std=c++11 -I/usr/include/cjson -I../src -I../src/cedmInterface -I../src/deviceutils/ -I../src/rfcInterface/ -I../src/iarmInterface/ -I../src/include/ -I./mocks/ -I./deviceutils/ -DGTEST_ENABLE -DGTEST_BASIC -DIARM_ENABLED -DRFC_API_ENABLED -DT2_EVENT_ENABLED
 
 # Define the libraries to link against
 COMMON_LDADD =  -lgtest -lgtest_main -lgmock_main -lgmock -lcjson -lgcov


### PR DESCRIPTION
* RDK-54955: Make rdkfwupdater buildable in docker container

Reason for change: * Making componentbuild in ubuntu docker container
Test Procedure: Build should pass with coverity
Risks: Low
Priority: P1



* RDK-54955: Make rdkfwupdater buildable in docker container

Reason for change: * Making componentbuild in ubuntu docker container
Test Procedure: Build should pass with coverity
Risks: Low
Priority: P1



* RDK-54955: Make rdkfwupdater buildable in docker container

Reason for change: * Making componentbuild in ubuntu docker container
Test Procedure: Build should pass with coverity
Risks: Low
Priority: P1



* RDK-54955: Make rdkfwupdater buildable in docker container

Reason for change: * Making componentbuild in ubuntu docker container
Test Procedure: Build should pass with coverity
Risks: Low
Priority: P1



* RDK-54955: Make rdkfwupdater buildable in docker container

Reason for change: * Making componentbuild in ubuntu docker container
Test Procedure: Build should pass with coverity
Risks: Low
Priority: P1



* RDK-54955: Make rdkfwupdater buildable in docker container

Reason for change: * Making component build in ubuntu docker container
		   * Fix L1 test issue fix
Test Procedure: Build should pass with coverity
Risks: Low
Priority: P1



* RDK-54955: Make rdkfwupdater buildable in docker container

Reason for change: * Making component build in ubuntu docker container
                   * Fix L1 test issue fix
Test Procedure: Build should pass with coverity
Risks: Low
Priority: P1



* RDK-54955: Make rdkfwupdater buildable in docker container

Reason for change: * Making component build in ubuntu docker container
                   * Fix L1 test issue fix
Test Procedure: Build should pass with coverity
Risks: Low
Priority: P1



---------