### PR TITLE
RDK-54955: Make rdkfwupdater buildable in docker container

### DIFF
--- a/.github/workflows/native_full_build.yml
+++ b/.github/workflows/native_full_build.yml
@@ -1,0 +1,22 @@
+name: Build Component in Native Environment
+
+on:
+  pull_request:
+    branches: [ develop ]
+    paths: ['**/*.c', '**/*.cpp', '**/*.cc', '**/*.cxx', '**/*.h', '**/*.hpp']
+
+jobs:
+  build-breakpad-wrapper-on-pr:
+    name: Build breakpad wrapper component in github rdkcentral
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/rdkcentral/docker-device-mgt-service-test/native-platform:latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: native build
+        run: |
+          chmod +x cov_build.sh
+          sh -e cov_build.sh


### PR DESCRIPTION
Reason for change: * Adding yml file to fetch docker image
Test Procedure: Build should pass with coverity
Risks: Low
Priority: P1