### PR TITLE
RDK-55339:Secure unlock of Platform Services - CDL

### DIFF
--- a/src/rfcInterface/rfcinterface.c
+++ b/src/rfcInterface/rfcinterface.c
@@ -230,6 +230,30 @@ int isIncremetalCDLEnable(const char *file_name)
     return chunk_dwld;
 }
 
+/* Description:Checking debug services rfc status
+ * @param type : void
+ * @return bool true : enable and false: disable
+ * */
+bool isDebugServicesEnabled(void)
+{
+    bool status =false;
+    int ret = -1;
+    char rfc_data[RFC_VALUE_BUF_SIZE];
+
+    *rfc_data = 0;
+    ret = read_RFCProperty("DIRECTCDN", RFC_DEBUGSRV, rfc_data, sizeof(rfc_data));
+    if (ret == -1) {
+        SWLOG_ERROR("%s: rfc Debug services =%s failed Status %d\n", __FUNCTION__, RFC_DEBUGSRV, ret);
+        return status;
+    } else {
+        SWLOG_INFO("%s: rfc Debug services = %s\n", __FUNCTION__, rfc_data);
+        if ((strncmp(rfc_data, "true", 4)) == 0) {
+            status = true;
+        }
+    }
+    return status;
+}
+
 /* Description: Cheacking notify rfc status
  * @param type : void
  * @return bool true : enable and false: disable


### PR DESCRIPTION
Reason for change: Adding a function to fetch Dbg services RFC value
Test Procedure: Turn on RFC and  verify
Risks: Low
Priority: P1