### PR TITLE
RDK-55339:Secure unlock of Platform Services - CDL

### DIFF
--- a/src/rfcInterface/rfcinterface.h
+++ b/src/rfcInterface/rfcinterface.h
@@ -85,6 +85,7 @@ typedef struct rfcdetails {
 #define RFC_FW_DWNL_END "Device.DeviceInfo.X_RDKCENTRAL-COM_xOpsDeviceMgmt.RPC.FirmwareDownloadCompletedNotification"
 #define RFC_FW_REBOOT_NOTIFY "Device.DeviceInfo.X_RDKCENTRAL-COM_xOpsDeviceMgmt.RPC.RebootPendingNotification"
 #define RFC_FW_AUTO_EXCLUDE "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.FWUpdate.AutoExcluded.Enable"
+#define RFC_DEBUGSRV "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Identity.DbgServices.Enable"
 
 int getRFCSettings(Rfc_t *rfc_list);
 
@@ -94,5 +95,6 @@ int write_RFCProperty(char* type, const char* key, const char *data, RFCVALDATAT
 int isMtlsEnabled(const char *);
 int isIncremetalCDLEnable(const char *file_name);
 bool isMmgbleNotifyEnabled(void);
+bool isDebugServicesEnabled(void);
 
 #endif /* VIDEO_RFCINTERFACE_RFCINTERFACE_H_ */


### PR DESCRIPTION
Reason for change: Add check for enable debug services RFC
Test Procedure: Turn on RFC and  verify
Risks: Low
Priority: P1