### PR TITLE
RDK-55339:Secure unlock of Platform Services - CDL

### DIFF
--- a/src/deviceutils/device_api.c
+++ b/src/deviceutils/device_api.c
@@ -1292,7 +1292,7 @@ size_t GetServURL( char *pServURL, size_t szBufSize )
         GetBuildType( buf, sizeof(buf), &eBuildType );
         if( isInStateRed() )
         {
-            if(( eBuildType != ePROD )  || ( dbgServices))
+            if(( eBuildType != ePROD )  || ( dbgServices == true ))
             {
                 len = GetServerUrlFile( pServURL, szBufSize, STATE_RED_CONF );
             }
@@ -1303,7 +1303,7 @@ size_t GetServURL( char *pServURL, size_t szBufSize )
         }
         else
         {
-            if(( eBuildType != ePROD )  || ( dbgServices))
+            if(( eBuildType != ePROD )  || ( dbgServices == true ))
             {
                 if( (filePresentCheck( SWUPDATE_CONF ) == RDK_API_SUCCESS) )    // if the file exists
                 {

--- a/src/deviceutils/device_api.c
+++ b/src/deviceutils/device_api.c
@@ -1284,7 +1284,7 @@ size_t GetServURL( char *pServURL, size_t szBufSize )
     BUILDTYPE eBuildType;
     char buf[URL_MAX_LEN];
     bool skip = false;
-	bool dbgServices = isDebugServicesEnabled(); //check debug services enabled
+    bool dbgServices = isDebugServicesEnabled(); //check debug services enabled
 
     if( pServURL != NULL )
     {

--- a/src/deviceutils/device_api.c
+++ b/src/deviceutils/device_api.c
@@ -81,7 +81,7 @@ size_t GetServerUrlFile( char *pServUrl, size_t szBufSize, char *pFileName )
                     pLb = pHttp + 8;    // reuse pLb for parsing, pLb should point to first character after https://
                     while( *pLb )   // convert non-alpha numerics (but not '.') or whitespace to NULL terminator
                     {
-                        if( (!isalnum( *pLb ) && *pLb != '.' && *pLb != '/' && *pLb != '-' && *pLb != '_') || isspace( *pLb ) )
+                        if( (!isalnum( *pLb ) && *pLb != '.' && *pLb != '/' && *pLb != '-' && *pLb != '_' && *pLb != ':') || isspace( *pLb ) )
                         {
                             *pLb = 0;   // NULL terminate at end of URL
                             break;

--- a/src/deviceutils/device_api.c
+++ b/src/deviceutils/device_api.c
@@ -1284,6 +1284,7 @@ size_t GetServURL( char *pServURL, size_t szBufSize )
     BUILDTYPE eBuildType;
     char buf[URL_MAX_LEN];
     bool skip = false;
+	bool dbgServices = isDebugServicesEnabled(); //check debug services enabled
 
     if( pServURL != NULL )
     {
@@ -1291,7 +1292,7 @@ size_t GetServURL( char *pServURL, size_t szBufSize )
         GetBuildType( buf, sizeof(buf), &eBuildType );
         if( isInStateRed() )
         {
-            if( eBuildType != ePROD )
+            if(( eBuildType != ePROD )  || ( dbgServices))
             {
                 len = GetServerUrlFile( pServURL, szBufSize, STATE_RED_CONF );
             }
@@ -1302,7 +1303,7 @@ size_t GetServURL( char *pServURL, size_t szBufSize )
         }
         else
         {
-            if( eBuildType != ePROD )
+            if(( eBuildType != ePROD )  || ( dbgServices))
             {
                 if( (filePresentCheck( SWUPDATE_CONF ) == RDK_API_SUCCESS) )    // if the file exists
                 {

--- a/src/rfcInterface/rfcinterface.c
+++ b/src/rfcInterface/rfcinterface.c
@@ -267,8 +267,7 @@ bool isDebugServicesEnabled(void)
     *rfc_data = 0;
     ret = read_RFCProperty("DEBUGSRV", RFC_DEBUGSRV, rfc_data, sizeof(rfc_data));
     if (ret == -1) {
-        SWLOG_ERROR("%s: rfc Debug services =%s failed Status %d\n", __FUNCTION__, RFC_DEBUGSRV, ret);
-        return status;
+        SWLOG_ERROR("%s: rfc Debug services =%s failed Status %d\n", __FUNCTION__, RFC_DEBUGSRV, ret);	
     } else {
         SWLOG_INFO("%s: rfc Debug services = %s\n", __FUNCTION__, rfc_data);
         if ((strncmp(rfc_data, "true", 4)) == 0) {

--- a/src/rfcInterface/rfcinterface.c
+++ b/src/rfcInterface/rfcinterface.c
@@ -253,3 +253,27 @@ bool isMmgbleNotifyEnabled(void)
     }
     return status;
 }
+
+/* Description: Cheacking notify rfc status
+ * @param type : void
+ * @return bool true : enable and false: disable
+ * */
+bool isDebugServicesEnabled(void)
+{
+    bool status =false;
+    int ret = -1;
+    char rfc_data[RFC_VALUE_BUF_SIZE];
+
+    *rfc_data = 0;
+    ret = read_RFCProperty("DIRECTCDN", RFC_DEBUGSRV, rfc_data, sizeof(rfc_data));
+    if (ret == -1) {
+        SWLOG_ERROR("%s: rfc Debug services =%s failed Status %d\n", __FUNCTION__, RFC_DEBUGSRV, ret);
+        return status;
+    } else {
+        SWLOG_INFO("%s: rfc Debug services = %s\n", __FUNCTION__, rfc_data);
+        if ((strncmp(rfc_data, "true", 4)) == 0) {
+            status = true;
+        }
+    }
+    return status;
+}

--- a/src/rfcInterface/rfcinterface.c
+++ b/src/rfcInterface/rfcinterface.c
@@ -265,7 +265,7 @@ bool isDebugServicesEnabled(void)
     char rfc_data[RFC_VALUE_BUF_SIZE];
 
     *rfc_data = 0;
-    ret = read_RFCProperty("DIRECTCDN", RFC_DEBUGSRV, rfc_data, sizeof(rfc_data));
+    ret = read_RFCProperty("DEBUGSRV", RFC_DEBUGSRV, rfc_data, sizeof(rfc_data));
     if (ret == -1) {
         SWLOG_ERROR("%s: rfc Debug services =%s failed Status %d\n", __FUNCTION__, RFC_DEBUGSRV, ret);
         return status;

--- a/src/rfcInterface/rfcinterface.h
+++ b/src/rfcInterface/rfcinterface.h
@@ -95,5 +95,6 @@ int write_RFCProperty(char* type, const char* key, const char *data, RFCVALDATAT
 int isMtlsEnabled(const char *);
 int isIncremetalCDLEnable(const char *file_name);
 bool isMmgbleNotifyEnabled(void);
+bool isDebugServicesEnabled(void);
 
 #endif /* VIDEO_RFCINTERFACE_RFCINTERFACE_H_ */

--- a/src/rfcInterface/rfcinterface.h
+++ b/src/rfcInterface/rfcinterface.h
@@ -85,6 +85,7 @@ typedef struct rfcdetails {
 #define RFC_FW_DWNL_END "Device.DeviceInfo.X_RDKCENTRAL-COM_xOpsDeviceMgmt.RPC.FirmwareDownloadCompletedNotification"
 #define RFC_FW_REBOOT_NOTIFY "Device.DeviceInfo.X_RDKCENTRAL-COM_xOpsDeviceMgmt.RPC.RebootPendingNotification"
 #define RFC_FW_AUTO_EXCLUDE "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.FWUpdate.AutoExcluded.Enable"
+#define RFC_DEBUGSRV "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Identity.DbgServices.Enable"
 
 int getRFCSettings(Rfc_t *rfc_list);
 

--- a/unittest/deviceutils/device_api_gtest.cpp
+++ b/unittest/deviceutils/device_api_gtest.cpp
@@ -465,7 +465,7 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_Nullcheck)
 {
     EXPECT_EQ(GetServURL(NULL, 0), 0);
 }
-TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered_Rfc_True)
+TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered_DebugServices_Enabled)
 {
     char output[16];
     int ret;
@@ -480,7 +480,7 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered_Rfc_True)
     ret = system("rm -f /tmp/device_gtest.prop");
     printf("Server URL = %s\n", output);
 }
-TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered_Rfc_False)
+TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered_DebugServices_Disabled)
 {
     char output[16];
     int ret;
@@ -495,7 +495,7 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered_Rfc_False)
     ret = system("rm -f /tmp/device_gtest.prop");
     printf("Server URL = %s\n", output);
 }
-TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered_Prod_Rfc_False)
+TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered_Prod_DebugServices_Enabled)
 {
     char output[16];
     int ret;
@@ -505,12 +505,12 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered_Prod_Rfc_False)
     //EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(1));
     EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(false));
     ret = system("echo \"https://www.statered.com\" > /tmp/stateredrecovry.conf");
-    EXPECT_NE(GetTR181Url(output, sizeof(output)), 0);
+    EXPECT_NE(GetServUrl(output, sizeof(output)), 0);
     ret = system("rm -f /tmp/stateredrecovry.conf");
     ret = system("rm -f /tmp/device_gtest.prop");
     printf("Server URL = %s\n", output);
 }
-TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered_Prod_Rfc_True)
+TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered_Prod_DebugServices_Disabled)
 {
     char output[16];
     int ret;
@@ -525,7 +525,7 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered_Prod_Rfc_True)
     ret = system("rm -f /tmp/device_gtest.prop");
     printf("Server URL = %s\n", output);
 }
-TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_Rfc_False)
+TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_DebugServices_Enabled)
 {
     char output[16];
     int ret;
@@ -541,7 +541,7 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_Rfc_False)
     printf("Server URL = %s\n", output);
 }
 
-TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_Rfc_True)
+TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_DebugServices_Disabled)
 {
     char output[16];
     int ret;
@@ -551,13 +551,13 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_Rfc_True)
     ret = system("echo \"BUILD_TYPE=vbn\" > /tmp/device_gtest.prop");
     EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(true));
     ret = system("echo \"https://www.rdkautotool.com\" > /tmp/swupdate.conf");
-    EXPECT_NE(GetTR181Url(output, sizeof(output)), 0);
+    EXPECT_NE(GetServUrl(output, sizeof(output)), 0);
     ret = system("rm -f /tmp/swupdate.conf");
     ret = system("rm -f /tmp/device_gtest.prop");
     printf("Server URL = %s\n", output);
 }
 
-TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_Prod_Rfc_True)
+TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_Prod_DebugServices_Enabled)
 {
     char output[16];
     int ret;
@@ -573,7 +573,7 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_Prod_Rfc_True)
     printf("Server URL = %s\n", output);
 }
 
-TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_Prod_Rfc_False)
+TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_Prod_DebugServices_Disabled)
 {
     char output[16];
     int ret;
@@ -583,37 +583,16 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_Prod_Rfc_False)
     ret = system("echo \"BUILD_TYPE=PROD\" > /tmp/device_gtest.prop");
     EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(false));
     ret = system("echo \"https://www.rdkautotool.com\" > /tmp/swupdate.conf");
-    EXPECT_NE(GetServURL(output, sizeof(output)), 0);
+    EXPECT_CALL(*g_DeviceUtilsMock, GetTR181URL(_, _))
+                .Times(1)
+                .WillOnce(Invoke([&output]( size_t TR181URL eURL, char *pUrlOut, size_t szBufSize ) {
+                int len = 0;
+		len = snprintf(pUrlOut, szBufSize, "%s", "TR181URL" );
+                return strlen(PUrlOut);
+        })); 
+    EXPECT_STREQ(GetServURL(output, "TR181URL/xconf/swu/stb"));
     ret = system("rm -f /tmp/swupdate.conf");
     ret = system("rm -f /tmp/device_gtest.prop");
-    printf("Server URL = %s\n", output);
-}
-TEST_F(DeviceApiTestFixture, TestName_GetServURL_RfcUrlStatered)
-{
-    char output[16];
-    int ret;
-    EXPECT_CALL(*g_DeviceUtilsMock, isInStateRed()).Times(1).WillOnce(Return(true));
-    EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _)).Times(1).WillOnce(Return(1));
-    //EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(-1));
-    ret = system("echo \"BUILD_TYPE=vbn\" > /tmp/device_gtest.prop");
-    //ret = system("echo \"https://www.statered.com\" > /tmp/stateredrecovry.conf");
-    EXPECT_NE(GetServURL(output, sizeof(output)), 0);
-    //ret = system("rm -f /tmp/stateredrecovry.conf");
-    ret = system("rm -f /tmp/device_gtest.prop");
-    printf("Server URL = %s\n", output);
-}
-TEST_F(DeviceApiTestFixture, TestName_GetServURL_RfcUrlSwupdate)
-{
-    char output[16];
-    int ret;
-    EXPECT_CALL(*g_DeviceUtilsMock, isInStateRed()).Times(1).WillOnce(Return(false));
-    EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _)).Times(1).WillOnce(Return(1));
-    EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(-1));
-    ret = system("echo \"https://www.rdkautotool.com\" > /tmp/swupdate.conf");
-    ret = system("echo \"BUILD_TYPE=vbn\" > /tmp/device_gtest.prop");
-    EXPECT_NE(GetServURL(output, sizeof(output)), 0);
-    ret = system("rm -f /tmp/swupdate.conf");
-    ret = system("rm -f /tmp/device_gtest.pro");
     printf("Server URL = %s\n", output);
 }
 TEST_F(DeviceApiTestFixture, TestName_GetBuildType_Success)

--- a/unittest/deviceutils/device_api_gtest.cpp
+++ b/unittest/deviceutils/device_api_gtest.cpp
@@ -505,7 +505,7 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered_Prod_DebugServi
     //EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(1));
     EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(false));
     ret = system("echo \"https://www.statered.com\" > /tmp/stateredrecovry.conf");
-    EXPECT_NE(GetServUrl(output, sizeof(output)), 0);
+    EXPECT_NE(GetServURL(output, sizeof(output)), 0);
     ret = system("rm -f /tmp/stateredrecovry.conf");
     ret = system("rm -f /tmp/device_gtest.prop");
     printf("Server URL = %s\n", output);
@@ -551,7 +551,7 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_DebugServices_D
     ret = system("echo \"BUILD_TYPE=vbn\" > /tmp/device_gtest.prop");
     EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(true));
     ret = system("echo \"https://www.rdkautotool.com\" > /tmp/swupdate.conf");
-    EXPECT_NE(GetServUrl(output, sizeof(output)), 0);
+    EXPECT_NE(GetServURL(output, sizeof(output)), 0);
     ret = system("rm -f /tmp/swupdate.conf");
     ret = system("rm -f /tmp/device_gtest.prop");
     printf("Server URL = %s\n", output);
@@ -563,7 +563,6 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_Prod_DebugServi
     int ret;
     EXPECT_CALL(*g_DeviceUtilsMock, isInStateRed()).Times(1).WillOnce(Return(false));
     EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(0));
-    //EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _)).Times(1).WillOnce(Return(1));
     ret = system("echo \"BUILD_TYPE=PROD\" > /tmp/device_gtest.prop");
     EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(true));
     ret = system("echo \"https://www.rdkautotool.com\" > /tmp/swupdate.conf");
@@ -578,21 +577,10 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_Prod_DebugServi
     char output[16];
     int ret;
     EXPECT_CALL(*g_DeviceUtilsMock, isInStateRed()).Times(1).WillOnce(Return(false));
-    EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(0));
-    //EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _)).Times(1).WillOnce(Return(1));
     ret = system("echo \"BUILD_TYPE=PROD\" > /tmp/device_gtest.prop");
     EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(false));
     ret = system("echo \"https://www.rdkautotool.com\" > /tmp/swupdate.conf");
-    EXPECT_CALL(*g_DeviceUtilsMock, GetTR181URL(_, _))
-                .Times(1)
-                .WillOnce(Invoke([&output]( size_t TR181URL eURL, char *pUrlOut, size_t szBufSize ) {
-                int len = 0;
-		len = snprintf(pUrlOut, szBufSize, "%s", "TR181URL" );
-                return strlen(PUrlOut);
-        })); 
-    ret = GetServURL(output , sizeof(output));
-    EXPECT_NE(ret ,0 );
-    EXPECT_STREQ(output, "TR181URL/xconf/swu/stb");
+    EXPECT_NE(GetServURL(output , sizeof(output)),0);
     ret = system("rm -f /tmp/swupdate.conf");
     ret = system("rm -f /tmp/device_gtest.prop");
     printf("Server URL = %s\n", output);

--- a/unittest/deviceutils/device_api_gtest.cpp
+++ b/unittest/deviceutils/device_api_gtest.cpp
@@ -467,75 +467,104 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_Nullcheck)
 }
 TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered_DebugServices_Enabled)
 {
-    char output[16];
+    char output[32];
     int ret;
+    char servUrl[]="https://www.statered.com";
     EXPECT_CALL(*g_DeviceUtilsMock, isInStateRed()).Times(1).WillOnce(Return(true));
     //EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _)).Times(1).WillOnce(Return(1));
     ret = system("echo \"BUILD_TYPE=vbn\" > /tmp/device_gtest.prop");
     //EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(1));
     EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(true));
     ret = system("echo \"https://www.statered.com\" > /tmp/stateredrecovry.conf");
-    EXPECT_NE(GetServURL(output, sizeof(output)), 0);
+    ret = GetServURL(output, sizeof(output));
+    EXPECT_EQ(strncmp(output,servUrl,strlen(servUrl)),0);
+    printf("output ====================================== %s \n",output);
+    printf("servUrl ===================================== %s \n" ,servUrl);
     ret = system("rm -f /tmp/stateredrecovry.conf");
     ret = system("rm -f /tmp/device_gtest.prop");
     printf("Server URL = %s\n", output);
 }
 TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered_DebugServices_Disabled)
 {
-    char output[16];
+    char output[32];
     int ret;
+    char servUrl[]="https://www.statered.com";
     EXPECT_CALL(*g_DeviceUtilsMock, isInStateRed()).Times(1).WillOnce(Return(true));
     //EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _)).Times(1).WillOnce(Return(1));
     ret = system("echo \"BUILD_TYPE=vbn\" > /tmp/device_gtest.prop");
     //EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(1));
     EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(false));
     ret = system("echo \"https://www.statered.com\" > /tmp/stateredrecovry.conf");
-    EXPECT_NE(GetServURL(output, sizeof(output)), 0);
+    ret = GetServURL(output, sizeof(output));
+    EXPECT_EQ(strncmp(output,servUrl,strlen(servUrl)),0);
+    printf("output ====================================== %s \n",output);
+    printf("servUrl ===================================== %s \n" ,servUrl);
     ret = system("rm -f /tmp/stateredrecovry.conf");
     ret = system("rm -f /tmp/device_gtest.prop");
     printf("Server URL = %s\n", output);
 }
 TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered_Prod_DebugServices_Enabled)
 {
-    char output[16];
+    char output[32];
     int ret;
+    char servUrl[]="https://www.statered.com";
     EXPECT_CALL(*g_DeviceUtilsMock, isInStateRed()).Times(1).WillOnce(Return(true));
     //EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _)).Times(1).WillOnce(Return(1));
     ret = system("echo \"BUILD_TYPE=PROD\" > /tmp/device_gtest.prop");
     //EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(1));
     EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(true));
     ret = system("echo \"https://www.statered.com\" > /tmp/stateredrecovry.conf");
-    EXPECT_NE(GetServURL(output, sizeof(output)), 0);
+    ret = GetServURL(output, sizeof(output));
+    EXPECT_EQ(strncmp(output,servUrl,strlen(servUrl)),0);
+    printf("output ====================================== %s\n ",output);
+    printf("servUrl ===================================== %s \n" ,servUrl);
     ret = system("rm -f /tmp/stateredrecovry.conf");
     ret = system("rm -f /tmp/device_gtest.prop");
     printf("Server URL = %s\n", output);
 }
 TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered_Prod_DebugServices_Disabled)
 {
-    char output[16];
+    char output[64];
     int ret;
+    char servUrl[]="https://www.tr181Rfc.com";
     EXPECT_CALL(*g_DeviceUtilsMock, isInStateRed()).Times(1).WillOnce(Return(true));
     //EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _)).Times(1).WillOnce(Return(1));
     ret = system("echo \"BUILD_TYPE=PROD\" > /tmp/device_gtest.prop");
     //EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(1));
     EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(false));
     ret = system("echo \"https://www.statered.com\" > /tmp/stateredrecovry.conf");
-    EXPECT_NE(GetServURL(output, sizeof(output)), 0);
+    ret = system("echo \"https://www.autotool.com\" > /tmp/swupdate.conf");
+    EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _))
+                .Times(1)
+                .WillOnce(Invoke([&servUrl]( char* type, const char* key, char *out_value, size_t datasize ) {
+                strncpy(out_value, servUrl , datasize-1);
+                out_value[datasize - 1] = '\0';
+                return strlen(out_value);
+                }));
+
+    ret=GetServURL(output , sizeof(output));
+    EXPECT_EQ(strncmp(output , servUrl , strlen(servUrl)),0);
+    printf("Output ========================= %s\n ", output);
+    printf("servUrl ======================== %s \n ",servUrl);
     ret = system("rm -f /tmp/stateredrecovry.conf");
     ret = system("rm -f /tmp/device_gtest.prop");
     printf("Server URL = %s\n", output);
 }
 TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_DebugServices_Enabled)
 {
-    char output[16];
+    char output[32];
     int ret;
+    char servUrl[]="https://www.rdkautotool.com";
     EXPECT_CALL(*g_DeviceUtilsMock, isInStateRed()).Times(1).WillOnce(Return(false));
     EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(0));
     //EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _)).Times(1).WillOnce(Return(1));
     ret = system("echo \"BUILD_TYPE=vbn\" > /tmp/device_gtest.prop");
     EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(true));
     ret = system("echo \"https://www.rdkautotool.com\" > /tmp/swupdate.conf");
-    EXPECT_NE(GetServURL(output, sizeof(output)), 0);
+    ret=GetServURL(output , sizeof(output));
+    EXPECT_EQ(strncmp(output , servUrl , strlen(servUrl)),0);
+    printf("Output ========================= %s\n ", output);
+    printf("servUrl ======================== %s \n ",servUrl);
     ret = system("rm -f /tmp/swupdate.conf");
     ret = system("rm -f /tmp/device_gtest.prop");
     printf("Server URL = %s\n", output);
@@ -543,15 +572,19 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_DebugServices_E
 
 TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_DebugServices_Disabled)
 {
-    char output[16];
+    char output[32];
     int ret;
+    char servUrl[]="https://www.rdkautotool.com";
     EXPECT_CALL(*g_DeviceUtilsMock, isInStateRed()).Times(1).WillOnce(Return(false));
     EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(0));
     //EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _)).Times(1).WillOnce(Return(1));
     ret = system("echo \"BUILD_TYPE=vbn\" > /tmp/device_gtest.prop");
     EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(false));
     ret = system("echo \"https://www.rdkautotool.com\" > /tmp/swupdate.conf");
-    EXPECT_NE(GetServURL(output, sizeof(output)), 0);
+    ret=GetServURL(output , sizeof(output));
+    EXPECT_EQ(strncmp(output , servUrl , strlen(servUrl)),0);
+    printf("Output ========================= %s\n ", output);
+    printf("servUrl ======================== %s \n ",servUrl);
     ret = system("rm -f /tmp/swupdate.conf");
     ret = system("rm -f /tmp/device_gtest.prop");
     printf("Server URL = %s\n", output);
@@ -559,14 +592,18 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_DebugServices_D
 
 TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_Prod_DebugServices_Enabled)
 {
-    char output[16];
+    char output[32];
     int ret;
+    char servUrl[]="https://www.rdkautotool.com";
     EXPECT_CALL(*g_DeviceUtilsMock, isInStateRed()).Times(1).WillOnce(Return(false));
     EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(0));
     ret = system("echo \"BUILD_TYPE=PROD\" > /tmp/device_gtest.prop");
     EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(true));
     ret = system("echo \"https://www.rdkautotool.com\" > /tmp/swupdate.conf");
-    EXPECT_NE(GetServURL(output, sizeof(output)), 0);
+    ret=GetServURL(output , sizeof(output));
+    EXPECT_EQ(strncmp(output , servUrl , strlen(servUrl)),0);
+    printf("Output ========================= %s\n ", output);
+    printf("servUrl ======================== %s \n ",servUrl);
     ret = system("rm -f /tmp/swupdate.conf");
     ret = system("rm -f /tmp/device_gtest.prop");
     printf("Server URL = %s\n", output);
@@ -574,13 +611,25 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_Prod_DebugServi
 
 TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_Prod_DebugServices_Disabled)
 {
-    char output[16];
+    char output[64];
     int ret;
+    char servUrl[]= "https://www.tr181Rfc.com";
     EXPECT_CALL(*g_DeviceUtilsMock, isInStateRed()).Times(1).WillOnce(Return(false));
     ret = system("echo \"BUILD_TYPE=PROD\" > /tmp/device_gtest.prop");
     EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(false));
     ret = system("echo \"https://www.rdkautotool.com\" > /tmp/swupdate.conf");
-    EXPECT_NE(GetServURL(output , sizeof(output)),0);
+    EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _))
+	        .Times(1)
+		.WillOnce(Invoke([&servUrl]( char* type, const char* key, char *out_value, size_t datasize ) {
+		strncpy(out_value, servUrl , datasize-1);
+                out_value[datasize - 1] = '\0';
+		return strlen(out_value);
+		}));
+
+    ret=GetServURL(output , sizeof(output));
+    EXPECT_EQ(strncmp(output , "https://www.tr181Rfc.com/xconf/swu/stb", strlen("https://www.tr181Rfc.com/xconf/swu/stb")),0);
+    printf("Output ========================= %s\n ", output);
+    printf("servUrl ======================== %s \n ",servUrl);
     ret = system("rm -f /tmp/swupdate.conf");
     ret = system("rm -f /tmp/device_gtest.prop");
     printf("Server URL = %s\n", output);

--- a/unittest/deviceutils/device_api_gtest.cpp
+++ b/unittest/deviceutils/device_api_gtest.cpp
@@ -503,7 +503,7 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered_Prod_DebugServi
     //EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _)).Times(1).WillOnce(Return(1));
     ret = system("echo \"BUILD_TYPE=PROD\" > /tmp/device_gtest.prop");
     //EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(1));
-    EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(false));
+    EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(true));
     ret = system("echo \"https://www.statered.com\" > /tmp/stateredrecovry.conf");
     EXPECT_NE(GetServURL(output, sizeof(output)), 0);
     ret = system("rm -f /tmp/stateredrecovry.conf");
@@ -518,7 +518,7 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered_Prod_DebugServi
     //EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _)).Times(1).WillOnce(Return(1));
     ret = system("echo \"BUILD_TYPE=PROD\" > /tmp/device_gtest.prop");
     //EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(1));
-    EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(true));
+    EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(false));
     ret = system("echo \"https://www.statered.com\" > /tmp/stateredrecovry.conf");
     EXPECT_NE(GetServURL(output, sizeof(output)), 0);
     ret = system("rm -f /tmp/stateredrecovry.conf");

--- a/unittest/deviceutils/device_api_gtest.cpp
+++ b/unittest/deviceutils/device_api_gtest.cpp
@@ -533,7 +533,7 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_DebugServices_E
     EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(0));
     //EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _)).Times(1).WillOnce(Return(1));
     ret = system("echo \"BUILD_TYPE=vbn\" > /tmp/device_gtest.prop");
-    EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(false));
+    EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(true));
     ret = system("echo \"https://www.rdkautotool.com\" > /tmp/swupdate.conf");
     EXPECT_NE(GetServURL(output, sizeof(output)), 0);
     ret = system("rm -f /tmp/swupdate.conf");
@@ -549,7 +549,7 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_DebugServices_D
     EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(0));
     //EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _)).Times(1).WillOnce(Return(1));
     ret = system("echo \"BUILD_TYPE=vbn\" > /tmp/device_gtest.prop");
-    EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(true));
+    EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(false));
     ret = system("echo \"https://www.rdkautotool.com\" > /tmp/swupdate.conf");
     EXPECT_NE(GetServURL(output, sizeof(output)), 0);
     ret = system("rm -f /tmp/swupdate.conf");

--- a/unittest/deviceutils/device_api_gtest.cpp
+++ b/unittest/deviceutils/device_api_gtest.cpp
@@ -465,7 +465,7 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_Nullcheck)
 {
     EXPECT_EQ(GetServURL(NULL, 0), 0);
 }
-TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered)
+TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered_Rfc_True)
 {
     char output[16];
     int ret;
@@ -473,13 +473,59 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered)
     //EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _)).Times(1).WillOnce(Return(1));
     ret = system("echo \"BUILD_TYPE=vbn\" > /tmp/device_gtest.prop");
     //EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(1));
+    EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(true));
     ret = system("echo \"https://www.statered.com\" > /tmp/stateredrecovry.conf");
     EXPECT_NE(GetServURL(output, sizeof(output)), 0);
     ret = system("rm -f /tmp/stateredrecovry.conf");
     ret = system("rm -f /tmp/device_gtest.prop");
     printf("Server URL = %s\n", output);
 }
-TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate)
+TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered_Rfc_False)
+{
+    char output[16];
+    int ret;
+    EXPECT_CALL(*g_DeviceUtilsMock, isInStateRed()).Times(1).WillOnce(Return(true));
+    //EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _)).Times(1).WillOnce(Return(1));
+    ret = system("echo \"BUILD_TYPE=vbn\" > /tmp/device_gtest.prop");
+    //EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(1));
+    EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(false));
+    ret = system("echo \"https://www.statered.com\" > /tmp/stateredrecovry.conf");
+    EXPECT_NE(GetServURL(output, sizeof(output)), 0);
+    ret = system("rm -f /tmp/stateredrecovry.conf");
+    ret = system("rm -f /tmp/device_gtest.prop");
+    printf("Server URL = %s\n", output);
+}
+TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered_Prod_Rfc_False)
+{
+    char output[16];
+    int ret;
+    EXPECT_CALL(*g_DeviceUtilsMock, isInStateRed()).Times(1).WillOnce(Return(true));
+    //EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _)).Times(1).WillOnce(Return(1));
+    ret = system("echo \"BUILD_TYPE=PROD\" > /tmp/device_gtest.prop");
+    //EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(1));
+    EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(false));
+    ret = system("echo \"https://www.statered.com\" > /tmp/stateredrecovry.conf");
+    EXPECT_NE(GetTR181Url(output, sizeof(output)), 0);
+    ret = system("rm -f /tmp/stateredrecovry.conf");
+    ret = system("rm -f /tmp/device_gtest.prop");
+    printf("Server URL = %s\n", output);
+}
+TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessStatered_Prod_Rfc_True)
+{
+    char output[16];
+    int ret;
+    EXPECT_CALL(*g_DeviceUtilsMock, isInStateRed()).Times(1).WillOnce(Return(true));
+    //EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _)).Times(1).WillOnce(Return(1));
+    ret = system("echo \"BUILD_TYPE=PROD\" > /tmp/device_gtest.prop");
+    //EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(1));
+    EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(true));
+    ret = system("echo \"https://www.statered.com\" > /tmp/stateredrecovry.conf");
+    EXPECT_NE(GetServURL(output, sizeof(output)), 0);
+    ret = system("rm -f /tmp/stateredrecovry.conf");
+    ret = system("rm -f /tmp/device_gtest.prop");
+    printf("Server URL = %s\n", output);
+}
+TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_Rfc_False)
 {
     char output[16];
     int ret;
@@ -487,6 +533,7 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate)
     EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(0));
     //EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _)).Times(1).WillOnce(Return(1));
     ret = system("echo \"BUILD_TYPE=vbn\" > /tmp/device_gtest.prop");
+    EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(false));
     ret = system("echo \"https://www.rdkautotool.com\" > /tmp/swupdate.conf");
     EXPECT_NE(GetServURL(output, sizeof(output)), 0);
     ret = system("rm -f /tmp/swupdate.conf");
@@ -494,6 +541,53 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate)
     printf("Server URL = %s\n", output);
 }
 
+TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_Rfc_True)
+{
+    char output[16];
+    int ret;
+    EXPECT_CALL(*g_DeviceUtilsMock, isInStateRed()).Times(1).WillOnce(Return(false));
+    EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(0));
+    //EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _)).Times(1).WillOnce(Return(1));
+    ret = system("echo \"BUILD_TYPE=vbn\" > /tmp/device_gtest.prop");
+    EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(true));
+    ret = system("echo \"https://www.rdkautotool.com\" > /tmp/swupdate.conf");
+    EXPECT_NE(GetTR181Url(output, sizeof(output)), 0);
+    ret = system("rm -f /tmp/swupdate.conf");
+    ret = system("rm -f /tmp/device_gtest.prop");
+    printf("Server URL = %s\n", output);
+}
+
+TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_Prod_Rfc_True)
+{
+    char output[16];
+    int ret;
+    EXPECT_CALL(*g_DeviceUtilsMock, isInStateRed()).Times(1).WillOnce(Return(false));
+    EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(0));
+    //EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _)).Times(1).WillOnce(Return(1));
+    ret = system("echo \"BUILD_TYPE=PROD\" > /tmp/device_gtest.prop");
+    EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(true));
+    ret = system("echo \"https://www.rdkautotool.com\" > /tmp/swupdate.conf");
+    EXPECT_NE(GetServURL(output, sizeof(output)), 0);
+    ret = system("rm -f /tmp/swupdate.conf");
+    ret = system("rm -f /tmp/device_gtest.prop");
+    printf("Server URL = %s\n", output);
+}
+
+TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_Prod_Rfc_False)
+{
+    char output[16];
+    int ret;
+    EXPECT_CALL(*g_DeviceUtilsMock, isInStateRed()).Times(1).WillOnce(Return(false));
+    EXPECT_CALL(*g_DeviceUtilsMock, filePresentCheck(_)).Times(1).WillOnce(Return(0));
+    //EXPECT_CALL(*g_DeviceUtilsMock, read_RFCProperty(_, _, _, _)).Times(1).WillOnce(Return(1));
+    ret = system("echo \"BUILD_TYPE=PROD\" > /tmp/device_gtest.prop");
+    EXPECT_CALL(*g_DeviceUtilsMock, isDebugServicesEnabled()).Times(1).WillOnce(Return(false));
+    ret = system("echo \"https://www.rdkautotool.com\" > /tmp/swupdate.conf");
+    EXPECT_NE(GetServURL(output, sizeof(output)), 0);
+    ret = system("rm -f /tmp/swupdate.conf");
+    ret = system("rm -f /tmp/device_gtest.prop");
+    printf("Server URL = %s\n", output);
+}
 TEST_F(DeviceApiTestFixture, TestName_GetServURL_RfcUrlStatered)
 {
     char output[16];

--- a/unittest/deviceutils/device_api_gtest.cpp
+++ b/unittest/deviceutils/device_api_gtest.cpp
@@ -590,7 +590,9 @@ TEST_F(DeviceApiTestFixture, TestName_GetServURL_SuccessSwupdate_Prod_DebugServi
 		len = snprintf(pUrlOut, szBufSize, "%s", "TR181URL" );
                 return strlen(PUrlOut);
         })); 
-    EXPECT_STREQ(GetServURL(output, "TR181URL/xconf/swu/stb"));
+    ret = GetServURL(output , sizeof(output));
+    EXPECT_NE(ret ,0 );
+    EXPECT_STREQ(output, "TR181URL/xconf/swu/stb");
     ret = system("rm -f /tmp/swupdate.conf");
     ret = system("rm -f /tmp/device_gtest.prop");
     printf("Server URL = %s\n", output);

--- a/unittest/fwdl_interface_gtest.cpp
+++ b/unittest/fwdl_interface_gtest.cpp
@@ -164,6 +164,16 @@ TEST_F(InterfaceTestFixture, TestName_isMmgbleNotifyEnabledSuccess)
     EXPECT_CALL(*g_InterfaceMock, getRFCParameter(_, _, _)).Times(1).WillOnce(Return(1));
     EXPECT_EQ(isMmgbleNotifyEnabled(), true);
 }
+TEST_F(InterfaceTestFixture, TestName_isDebugServicesEnabledFail)        
+{
+    EXPECT_CALL(*g_InterfaceMock, getRFCParameter(_, _, _)).Times(1).WillOnce(Return(-1));
+    EXPECT_EQ(isDebugServicesEnabled(), false);
+}
+TEST_F(InterfaceTestFixture, TestName_isDebugServicesEnableSuccess)
+{
+    EXPECT_CALL(*g_InterfaceMock, getRFCParameter(_, _, _)).Times(1).WillOnce(Return(1));
+    EXPECT_EQ(isDebugServicesEnabled(), true);
+}
 TEST_F(InterfaceTestFixture, TestName_isIncremetalCDLEnableSuccess)
 {
     EXPECT_CALL(*g_InterfaceMock, getRFCParameter(_, _, _)).Times(1).WillOnce(Return(1));

--- a/unittest/mocks/deviceutils_mock.cpp
+++ b/unittest/mocks/deviceutils_mock.cpp
@@ -176,6 +176,13 @@ extern "C" bool isInStateRed()
     return g_DeviceUtilsMock->isInStateRed();
 }
 
+extern "C" bool isDebugServicesEnabled(void) {
+        if (!g_DeviceUtilsMock) {
+            cout << "isDebugServicesEnabled g_DeviceUtilsMock object is NULL" << endl;
+	    return false; 
+        }
+        return g_DeviceUtilsMock->isDebugServicesEnabled();
+    }
 extern "C" size_t GetHwMacAddress( char *iface, char *pMac, size_t szBufSize )
 {
     if (!g_DeviceUtilsMock)

--- a/unittest/mocks/deviceutils_mock.cpp
+++ b/unittest/mocks/deviceutils_mock.cpp
@@ -183,6 +183,7 @@ extern "C" bool isDebugServicesEnabled(void) {
         }
         return g_DeviceUtilsMock->isDebugServicesEnabled();
     }
+
 extern "C" size_t GetHwMacAddress( char *iface, char *pMac, size_t szBufSize )
 {
     if (!g_DeviceUtilsMock)

--- a/unittest/mocks/deviceutils_mock.h
+++ b/unittest/mocks/deviceutils_mock.h
@@ -23,6 +23,7 @@
 
 #include "rdkv_cdl_log_wrapper.h"
 #define RDK_API_SUCCESS 0
+
 class DeviceUtilsInterface
 {
     public:
@@ -59,5 +60,6 @@ class DeviceUtilsMock: public DeviceUtilsInterface
 	MOCK_METHOD(bool, isInStateRed, (), ());
 	MOCK_METHOD(bool, isDebugServicesEnabled, (), ());
 	MOCK_METHOD(size_t, GetHwMacAddress, (char *iface, char *pMac, size_t szBufSize), ());
+
 };
 #endif

--- a/unittest/mocks/deviceutils_mock.h
+++ b/unittest/mocks/deviceutils_mock.h
@@ -38,6 +38,7 @@ class DeviceUtilsInterface
 	virtual int filePresentCheck(const char *filename) = 0;
 	virtual int getFileSize(const char *filename) = 0;
 	virtual bool isInStateRed() = 0;
+	virtual bool isDebugServicesEnabled() = 0;
         virtual size_t GetHwMacAddress( char *iface, char *pMac, size_t szBufSize ) = 0;
 };
 
@@ -56,6 +57,7 @@ class DeviceUtilsMock: public DeviceUtilsInterface
 	MOCK_METHOD(int, filePresentCheck, (const char *filename ), ());
 	MOCK_METHOD(int, getFileSize, (const char *filename ), ());
 	MOCK_METHOD(bool, isInStateRed, (), ());
+	MOCK_METHOD(bool, isDebugServicesEnabled, (), ());
 	MOCK_METHOD(size_t, GetHwMacAddress, (char *iface, char *pMac, size_t szBufSize), ());
 };
 #endif


### PR DESCRIPTION
Reason for change: Enable debug services on prod image w.r.t RFC
Test Procedure: Set debug services and verify 
Risks: Low
Priority: P1