### PR TITLE
RDKEMW-1798: Unable to connect url having port number

### DIFF
--- a/src/deviceutils/device_api.c
+++ b/src/deviceutils/device_api.c
@@ -81,7 +81,7 @@ size_t GetServerUrlFile( char *pServUrl, size_t szBufSize, char *pFileName )
                     pLb = pHttp + 8;    // reuse pLb for parsing, pLb should point to first character after https://
                     while( *pLb )   // convert non-alpha numerics (but not '.') or whitespace to NULL terminator
                     {
-                        if( (!isalnum( *pLb ) && *pLb != '.' && *pLb != '/' && *pLb != '-' && *pLb != '_') || isspace( *pLb ) )
+                        if( (!isalnum( *pLb ) && *pLb != '.' && *pLb != '/' && *pLb != '-' && *pLb != '_' && *pLb != ':') || isspace( *pLb ) )
                         {
                             *pLb = 0;   // NULL terminate at end of URL
                             break;


### PR DESCRIPTION
Reason for change: * mockxconf url having : and rdkvfwupdater consider
                     : as invalid
Test Procedure: Build should pass with this change and all L1  success
                Both server url swupdate.conf and reading url from xconf
                should pass with cdl success
Risks: Low
Priority: P1