### PR TITLE
RDKEMW-876: Added MigrationStatus in JsonString for Xconf

### DIFF
--- a/src/device_status_helper.c
+++ b/src/device_status_helper.c
@@ -824,6 +824,17 @@ size_t createJsonString( char *pPostFieldOut, size_t szPostFieldOut )
         remainlen = szPostFieldOut - totlen;
         totlen += snprintf( (pTmpPost + totlen), remainlen, "experience=%s", tmpbuf );
     }
+    len = GetMigrationReady( tmpbuf, sizeof(tmpbuf) );
+     if( len )
+     {
+         if( totlen )
+         {
+             *(pTmpPost + totlen) = '&';
+             ++totlen;
+         }
+         remainlen = szPostFieldOut - totlen;
+         totlen += snprintf( (pTmpPost + totlen), remainlen, "migrationReady=%s", tmpbuf );
+     }
     len = GetSerialNum( tmpbuf, sizeof(tmpbuf) );
     if( len )
     {

--- a/src/deviceutils/device_api.c
+++ b/src/deviceutils/device_api.c
@@ -632,6 +632,35 @@ size_t GetSerialNum( char *pSerialNum, size_t szBufSize )
     return i;
 }
 
+/* function GetMigrationReady - gets the migration readiness status.
+         Usage: size_t GetMigrationReady <char *pMRComponents> <size_t szBufSize>
+             pMRComponents - pointer to a char buffer to store the output string.
+             szBufSize - the size of the character buffer in argument 1.
+             RETURN - number of characters copied to the output buffer.
+ */
+ size_t GetMigrationReady( char *pMRComponents, size_t szBufSize )
+ {
+     size_t i = 0;
+ 
+     if( pMRComponents != NULL )
+     {
+         i = read_RFCProperty( "MigrationReady", MR_ID, pMRComponents, szBufSize );
+         if( i == READ_RFC_FAILURE )
+         {
+             i = 0;
+             SWLOG_ERROR( "GetMigrationReady: read_RFCProperty() failed Status %d\n", i );
+         }
+         else
+         {
+             i = strnlen( pMRComponents, szBufSize );
+         }
+     }
+     else
+     {
+         SWLOG_ERROR( "GetMigrationReady: Error, input argument NULL\n" );
+     }
+     return i;
+ }
 
 /* function GetExperience - gets the experience of the device.
  

--- a/src/deviceutils/device_api.h
+++ b/src/deviceutils/device_api.h
@@ -70,6 +70,7 @@ typedef enum {
 #define RFC_ACCOUNTID       "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AccountInfo.AccountID"
 #define RFC_SERIALNUM       "Device.DeviceInfo.SerialNumber"
 #define RFC_OS_CLASS        "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Bootstrap.OsClass"
+#define MR_ID               "Device.DeviceInfo.MigrationPreparer.MigrationReady"
 
 #define NO_URL              NULL
 
@@ -234,6 +235,19 @@ size_t GetSerialNum( char *pSerialNum, size_t szBufSize);
 */
 // TODO: GetExperience must be implemented correctly
 size_t GetExperience(char *pExperience, size_t szBufSize);
+
+
+/* function GetMigrationReady - gets the migration readiness status.
+
+ 	Usage: size_t GetMigrationReady <char *pMRComponents> <size_t szBufSize>
+
+ 	pMRComponents - pointer to a char buffer to store the output string.
+
+ 	szBufSize - the size of the character buffer in argument 1.
+
+ 	RETURN - number of characters copied to the output buffer.
+ */
+ size_t GetMigrationReady(char *pMRComponents, size_t szBufSize);
 
 
 /* function GetAccountID - gets the account ID of the device.

--- a/unittest/mocks/device_status_helper_mock.cpp
+++ b/unittest/mocks/device_status_helper_mock.cpp
@@ -157,6 +157,18 @@ extern "C" size_t GetExperience( char *pExperience, size_t szBufSize )
     return g_DeviceStatusMock->GetExperience(pExperience, szBufSize);
 }
 
+extern "C" size_t GetMigrationReady( char *pMigrationReady, size_t szBufSize )
+ {
+     if (!g_DeviceStatusMock)
+     {
+ 	cout << "GetMigrationReady  g_DeviceStatusMock object is NULL" << endl;
+         return 0;
+     }
+     printf("Inside Mock Function GetMigrationReady\n");
+     snprintf(pMigrationReady, szBufSize, "%s", "NO");
+     return g_DeviceStatusMock->GetMigrationReady(pMigrationReady, szBufSize);
+ }
+
 extern "C" size_t GetAccountID( char *pAccountID, size_t szBufSize )
 {
     if (!g_DeviceStatusMock)

--- a/unittest/mocks/device_status_helper_mock.h
+++ b/unittest/mocks/device_status_helper_mock.h
@@ -40,6 +40,7 @@ class DeviceStatusInterface
 	virtual size_t GetPartnerId( char *pPartnerId, size_t szBufSize ) = 0;
 	virtual size_t GetOsClass( char *pOsClass, size_t szBufSize ) = 0;
 	virtual size_t GetExperience( char *pExperience, size_t szBufSize ) = 0;
+	virtual size_t GetMigrationReady( char *pMigrationReady, size_t szBufSize ) = 0;
 	virtual size_t GetAccountID( char *pAccountID, size_t szBufSize ) = 0;
 	virtual size_t GetSerialNum( char *pSerialNum, size_t szBufSize ) = 0;
 	virtual size_t GetUTCTime( char *pUTCTime, size_t szBufSize ) = 0;
@@ -74,6 +75,7 @@ class DeviceStatusMock: public DeviceStatusInterface
     	MOCK_METHOD(size_t, GetPartnerId, ( char *pPartnerId, size_t szBufSize ), ());
     	MOCK_METHOD(size_t, GetOsClass, ( char *pOsClass, size_t szBufSize ), ());
     	MOCK_METHOD(size_t, GetExperience, ( char *pExperience, size_t szBufSize ), ());
+	MOCK_METHOD(size_t, GetMigrationReady, ( char *pMigrationReady, size_t szBufSize ), ());
     	MOCK_METHOD(size_t, GetAccountID, ( char *pAccountID, size_t szBufSize ), ());
     	MOCK_METHOD(size_t, GetSerialNum, ( char *pSerialNum, size_t szBufSize ), ());
     	MOCK_METHOD(size_t, GetUTCTime, ( char *pUTCTime, size_t szBufSize ), ());


### PR DESCRIPTION
Reason for change: For Migration from RDKV to RDKE
Test Procedure: None
Priority: P1   
Risks: Medium

Signed-off-by: Faizal Hasan.Z <faizalhasan_zahirhussain@comcast.com>

