### PR TITLE
RDKEMW-5953 Xconf rule gets changed for Westinghouse

### DIFF
--- a/src/deviceutils/device_api.c
+++ b/src/deviceutils/device_api.c
@@ -283,7 +283,7 @@ size_t GetAdditionalFwVerInfo( char *pAdditionalFwVerInfo, size_t szBufSize )
         {
             len += GetRemoteInfo( (pAdditionalFwVerInfo + len), (szBufSize - len) );
         }
-	    len = stripinvalidchar(pAdditionalFwVerInfo, szBufSize); // remove newline etc.
+	    len = stripinvalidchar(pAdditionalFwVerInfo, len); // remove newline etc.
     }
     else
     {

--- a/src/deviceutils/device_api.c
+++ b/src/deviceutils/device_api.c
@@ -283,6 +283,7 @@ size_t GetAdditionalFwVerInfo( char *pAdditionalFwVerInfo, size_t szBufSize )
         {
             len += GetRemoteInfo( (pAdditionalFwVerInfo + len), (szBufSize - len) );
         }
+	    len = stripinvalidchar(pAdditionalFwVerInfo, szBufSize); // remove newline etc.
     }
     else
     {


### PR DESCRIPTION
Reason for change: added fix to remove \n @ end of manufacturer
Test Procedure: Refer JIRA
Risks: Medium
Priority: P1