### PR TITLE
RDKTV-39830:Xumo TV devices got stuck with old firmware with http eror code 405

### DIFF
--- a/src/chunk.c
+++ b/src/chunk.c
@@ -107,11 +107,21 @@ int chunkDownload(FileDwnl_t *pfile_dwnl, MtlsAuth_t *sec, unsigned int speed_li
             SWLOG_INFO("chunkDownload() file size=%d and range=%s\n", file_size, range);
         }   else {
             SWLOG_ERROR( "chunkDownload() error getFileSize=%s\n", pfile_dwnl->pathname);
+            unlink(pfile_dwnl->pathname);
+            if ((filePresentCheck(headerfile)) == 0) {
+                unlink(headerfile);
+            }
             return -1;
         }
     }else {
         SWLOG_ERROR( "chunkDownload() Error to proceed for chunk download due to below reason.\nContent length not present=%zu or Partial image file not present.\n", content_len);
         t2CountNotify("SYST_ERR_FWCTNFetch", 1);
+        if ((filePresentCheck(pfile_dwnl->pathname)) == 0) {
+            unlink(pfile_dwnl->pathname);
+        }
+        if ((filePresentCheck(headerfile)) == 0) {
+            unlink(headerfile);
+        }
         return curl_code_header_req;
     }
     if (httpcode != NULL) {

--- a/src/include/rdkv_upgrade.h
+++ b/src/include/rdkv_upgrade.h
@@ -142,6 +142,7 @@ void dwnlError(int curl_code, int http_code, int server_type,const DevicePropert
 void saveHTTPCode(int http_code, const char *lastrun);
 void Upgradet2CountNotify(char *marker, int val); 
 void Upgradet2ValNotify( char *marker, char *val );
+size_t getContentLength(const char *file);
 #ifdef __cplusplus
 }
 #endif

--- a/src/rfcInterface/rfcinterface.c
+++ b/src/rfcInterface/rfcinterface.c
@@ -226,7 +226,6 @@ int isIncremetalCDLEnable(const char *file_name)
     SWLOG_INFO("%s: Checking IncremetalCDLEnable... Download image name=%s\n", __FUNCTION__, file_name);
 
     snprintf(headerfile, sizeof(headerfile), "%s.header", file_name);
-
     *rfc_data = 0;
     ret = read_RFCProperty("IncrementalCDL", RFC_INCR_CDL, rfc_data, sizeof(rfc_data));
     if(ret == -1) {

--- a/src/rfcInterface/rfcinterface.c
+++ b/src/rfcInterface/rfcinterface.c
@@ -230,7 +230,6 @@ int isIncremetalCDLEnable(const char *file_name)
     ret = read_RFCProperty("IncrementalCDL", RFC_INCR_CDL, rfc_data, sizeof(rfc_data));
     if(ret == -1) {
         SWLOG_ERROR("%s: IncrementalCDL rfc=%s failed Status %d\n", __FUNCTION__, RFC_MTLS, ret);
-		
 	return chunk_dwld;
     }else {
         SWLOG_INFO("%s: rfc IncrementalCDL= %s\n", __FUNCTION__, rfc_data);

--- a/src/rfcInterface/rfcinterface.c
+++ b/src/rfcInterface/rfcinterface.c
@@ -22,6 +22,7 @@
 #ifndef GTEST_ENABLE
 #include "rdk_fwdl_utils.h"
 #include "system_utils.h"
+#include "rdkv_upgrade.h"
 #endif
 
 /*
@@ -215,12 +216,16 @@ int isIncremetalCDLEnable(const char *file_name)
     int chunk_dwld = 0;
     int ret = -1;
     char rfc_data[RFC_VALUE_BUF_SIZE];
+    char headerfile[136];
+    size_t content_len = 0;
 
     if (file_name == NULL) {
         SWLOG_ERROR("%s : Parameter is NULL\n", __FUNCTION__);
         return chunk_dwld;
     }
     SWLOG_INFO("%s: Checking IncremetalCDLEnable... Download image name=%s\n", __FUNCTION__, file_name);
+
+    snprintf(headerfile, sizeof(headerfile), "%s.header", file_name);
 
     *rfc_data = 0;
     ret = read_RFCProperty("IncrementalCDL", RFC_INCR_CDL, rfc_data, sizeof(rfc_data));
@@ -230,12 +235,22 @@ int isIncremetalCDLEnable(const char *file_name)
     }else {
         SWLOG_INFO("%s: rfc IncrementalCDL= %s\n", __FUNCTION__, rfc_data);
     }
-
+     
     if((strncmp(rfc_data, "true", 4)) == 0) {
         SWLOG_INFO("%s :  incremental cdl is TRUE\n", __FUNCTION__);
         if((filePresentCheck(file_name)) == 0) {
-            chunk_dwld = 1;
-            SWLOG_INFO("%s: File=%s is present. IncrementalCDL enable=%d\n",__FUNCTION__, file_name, chunk_dwld);
+            if (0 < (getFileSize(file_name)) && (filePresentCheck(headerfile)) == 0 ) {
+		content_len = getContentLength(headerfile);
+		if(content_len > 0) {
+                chunk_dwld = 1;
+                SWLOG_INFO("%s: File=%s is present. IncrementalCDL enable=%d\n",__FUNCTION__, file_name, chunk_dwld);
+		}
+            } else {
+                unlink(file_name);
+                if ((filePresentCheck(headerfile)) == 0) {
+                    unlink(headerfile);
+                }
+            }
         }
     }
     return chunk_dwld;

--- a/src/rfcInterface/rfcinterface.c
+++ b/src/rfcInterface/rfcinterface.c
@@ -19,10 +19,10 @@
 #include "rfcinterface.h"
 
 #include "rdkv_cdl_log_wrapper.h"
+#include "rdkv_upgrade.h"
 #ifndef GTEST_ENABLE
 #include "rdk_fwdl_utils.h"
 #include "system_utils.h"
-#include "rdkv_upgrade.h"
 #endif
 
 /*

--- a/src/rfcInterface/rfcinterface.c
+++ b/src/rfcInterface/rfcinterface.c
@@ -231,11 +231,11 @@ int isIncremetalCDLEnable(const char *file_name)
     ret = read_RFCProperty("IncrementalCDL", RFC_INCR_CDL, rfc_data, sizeof(rfc_data));
     if(ret == -1) {
         SWLOG_ERROR("%s: IncrementalCDL rfc=%s failed Status %d\n", __FUNCTION__, RFC_MTLS, ret);
+		
 	return chunk_dwld;
     }else {
         SWLOG_INFO("%s: rfc IncrementalCDL= %s\n", __FUNCTION__, rfc_data);
     }
-     
     if((strncmp(rfc_data, "true", 4)) == 0) {
         SWLOG_INFO("%s :  incremental cdl is TRUE\n", __FUNCTION__);
         if((filePresentCheck(file_name)) == 0) {

--- a/src/rfcInterface/rfcinterface.c
+++ b/src/rfcInterface/rfcinterface.c
@@ -234,6 +234,7 @@ int isIncremetalCDLEnable(const char *file_name)
     }else {
         SWLOG_INFO("%s: rfc IncrementalCDL= %s\n", __FUNCTION__, rfc_data);
     }
+
     if((strncmp(rfc_data, "true", 4)) == 0) {
         SWLOG_INFO("%s :  incremental cdl is TRUE\n", __FUNCTION__);
         if((filePresentCheck(file_name)) == 0) {

--- a/src/rfcInterface/rfcinterface.c
+++ b/src/rfcInterface/rfcinterface.c
@@ -239,11 +239,15 @@ int isIncremetalCDLEnable(const char *file_name)
         SWLOG_INFO("%s :  incremental cdl is TRUE\n", __FUNCTION__);
         if((filePresentCheck(file_name)) == 0) {
             if (0 < (getFileSize(file_name)) && (filePresentCheck(headerfile)) == 0 ) {
-		content_len = getContentLength(headerfile);
-		if(content_len > 0) {
-                chunk_dwld = 1;
-                SWLOG_INFO("%s: File=%s is present. IncrementalCDL enable=%d\n",__FUNCTION__, file_name, chunk_dwld);
-		}
+                content_len = getContentLength(headerfile);
+                if(content_len > 0) {
+                    chunk_dwld = 1;
+                    SWLOG_INFO("%s: File=%s is present. IncrementalCDL enable=%d\n",__FUNCTION__, file_name, chunk_dwld);
+                } else {
+                    /* Invalid or missing Content-Length: remove partial download */
+                    unlink(file_name);
+                    unlink(headerfile);
+                }
             } else {
                 unlink(file_name);
                 if ((filePresentCheck(headerfile)) == 0) {

--- a/src/rfcInterface/rfcinterface.c
+++ b/src/rfcInterface/rfcinterface.c
@@ -246,10 +246,12 @@ int isIncremetalCDLEnable(const char *file_name)
                     SWLOG_INFO("%s: File=%s is present. IncrementalCDL enable=%d\n",__FUNCTION__, file_name, chunk_dwld);
                 } else {
                     /* Invalid or missing Content-Length: remove partial download */
+                    SWLOG_INFO("Invalid or missing Content-Length: remove partial download\n");
                     unlink(file_name);
                     unlink(headerfile);
                 }
             } else {
+                SWLOG_INFO("Invalid or missing header: remove partial download\n");
                 unlink(file_name);
                 if ((filePresentCheck(headerfile)) == 0) {
                     unlink(headerfile);

--- a/src/rfcInterface/rfcinterface.c
+++ b/src/rfcInterface/rfcinterface.c
@@ -18,6 +18,7 @@
 
 #include "rfcinterface.h"
 
+#include <unistd.h>
 #include "rdkv_cdl_log_wrapper.h"
 #include "rdkv_upgrade.h"
 #ifndef GTEST_ENABLE

--- a/unittest/Makefile.am
+++ b/unittest/Makefile.am
@@ -18,7 +18,7 @@
 AUTOMAKE_OPTIONS = subdir-objects
 
 # Define the program name and the source files
-bin_PROGRAMS = rdkfw_device_status_gtest rdkfw_deviceutils_gtest rdkfw_main_gtest rdkfw_interface_gtest rdkfwupdatemgr_main_flow_gtest rdkFwupdateMgr_handlers_gtest dbus_handlers_gtest
+bin_PROGRAMS = rdkfw_device_status_gtest rdkfw_deviceutils_gtest rdkfw_main_gtest rdkfw_interface_gtest rdkfwupdatemgr_main_flow_gtest rdkFwupdateMgr_handlers_gtest rdkFwupdateMgr_async_main_flow_gtest rdkFwupdateMgr_async_handlers_gtest dbus_handlers_gtest
 # Define the include directories
 # NOTE: We explicitly use -I. to prioritize local test headers over system headers
 # This prevents conflicts with external library headers in /usr/local/include/

--- a/unittest/Makefile.am
+++ b/unittest/Makefile.am
@@ -18,8 +18,7 @@
 AUTOMAKE_OPTIONS = subdir-objects
 
 # Define the program name and the source files
-bin_PROGRAMS = rdkfw_device_status_gtest rdkfw_deviceutils_gtest rdkfw_main_gtest rdkfw_interface_gtest rdkfwupdatemgr_main_flow_gtest rdkFwupdateMgr_handlers_gtest dbus_handlers_gtest rdkFwupdateMgr_async_refcount_gtest rdkFwupdateMgr_async_stress_gtest rdkFwupdateMgr_async_cleanup_gtest rdkFwupdateMgr_async_signal_gtest rdkFwupdateMgr_async_threadsafety_gtest
-#bin_PROGRAMS = rdkfw_device_status_gtest rdkfw_deviceutils_gtest rdkfw_main_gtest rdkfw_interface_gtest  dbus_handlers_gtest
+bin_PROGRAMS = rdkfw_device_status_gtest rdkfw_deviceutils_gtest rdkfw_main_gtest rdkfw_interface_gtest rdkfwupdatemgr_main_flow_gtest rdkFwupdateMgr_handlers_gtest dbus_handlers_gtest
 # Define the include directories
 # NOTE: We explicitly use -I. to prioritize local test headers over system headers
 # This prevents conflicts with external library headers in /usr/local/include/

--- a/unittest/basic_rdkv_main_gtest.cpp
+++ b/unittest/basic_rdkv_main_gtest.cpp
@@ -653,6 +653,86 @@ TEST(MainHelperFunctionTest,chunkDownloadgetfilesizeTestFail){
     g_DeviceUtilsMock = &Deviceglobal;
     global_mockexternal_ptr = NULL;
 }
+
+/* Test: Verify that when getFileSize() returns -1 (error), chunkDownload()
+ * cleans up both the partial image file and its .header file via unlink(). */
+TEST(MainHelperFunctionTest,chunkDownloadgetfilesizeFailCleansUpFiles){
+    MockExternal mockexternal;
+    global_mockexternal_ptr = &mockexternal;
+    DeviceUtilsMock DeviceMock;
+    g_DeviceUtilsMock = &DeviceMock;
+    MockExternal mock;
+    g_DeviceUtilsMock = &DeviceMock;
+    global_mockexternal_ptr = &mock;
+
+    int httpcode = -1;
+    int ret = 0;
+    FileDwnl_t file;
+    memset(&file, '\0', sizeof(file));
+    snprintf(file.pathname, sizeof(file.pathname),"%s", "/tmp/testfirmware_cleanup1.bin");
+
+    /* Create real files so unlink() has something to remove */
+    ret = system("echo 'partial data' > /tmp/testfirmware_cleanup1.bin");
+    ret = system("echo 'Content-Length: 1234' > /tmp/testfirmware_cleanup1.bin.header");
+
+    /* filePresentCheck returns 0 (file exists) for all checks */
+    EXPECT_CALL(DeviceMock, filePresentCheck(_)).WillRepeatedly(Return(0));
+    /* getFileSize returns -1 to trigger the error/cleanup path */
+    EXPECT_CALL(DeviceMock, getFileSize(_)).WillRepeatedly(Return(-1));
+
+    EXPECT_EQ(chunkDownload(&file, NULL, 0, &httpcode), -1);
+
+    /* Verify both files were cleaned up by unlink() */
+    EXPECT_NE(access("/tmp/testfirmware_cleanup1.bin", F_OK), 0)
+        << "Partial image file should have been removed";
+    EXPECT_NE(access("/tmp/testfirmware_cleanup1.bin.header", F_OK), 0)
+        << "Header file should have been removed";
+
+    /* Safety cleanup in case test assertions fail */
+    ret = system("rm -f /tmp/testfirmware_cleanup1.bin /tmp/testfirmware_cleanup1.bin.header");
+    global_mockexternal_ptr = NULL;
+    g_DeviceUtilsMock = &Deviceglobal;
+}
+
+/* Test: Verify that when content_len is 0 (no Content-Length in header)
+ * and the partial file is present, chunkDownload() cleans up both files. */
+TEST(MainHelperFunctionTest,chunkDownloadNoContentLenCleansUpFiles){
+    MockExternal mockexternal;
+    global_mockexternal_ptr = &mockexternal;
+    DeviceUtilsMock DeviceMock;
+    g_DeviceUtilsMock = &DeviceMock;
+    MockExternal mock;
+    g_DeviceUtilsMock = &DeviceMock;
+    global_mockexternal_ptr = &mock;
+
+    int httpcode = -1;
+    int ret = 0;
+    FileDwnl_t file;
+    memset(&file, '\0', sizeof(file));
+    snprintf(file.pathname, sizeof(file.pathname),"%s", "/tmp/testfirmware_cleanup2.bin");
+
+    /* Create partial image file and a header file with NO Content-Length line */
+    ret = system("echo 'partial data' > /tmp/testfirmware_cleanup2.bin");
+    ret = system("echo 'No-Content-Here' > /tmp/testfirmware_cleanup2.bin.header");
+
+    /* filePresentCheck returns 0 (file exists) for all checks */
+    EXPECT_CALL(DeviceMock, filePresentCheck(_)).WillRepeatedly(Return(0));
+    EXPECT_CALL(DeviceMock, getFileSize(_)).WillRepeatedly(Return(12));
+
+    EXPECT_EQ(chunkDownload(&file, NULL, 0, &httpcode), -1);
+
+    /* Verify both files were cleaned up by unlink() */
+    EXPECT_NE(access("/tmp/testfirmware_cleanup2.bin", F_OK), 0)
+        << "Partial image file should have been removed";
+    EXPECT_NE(access("/tmp/testfirmware_cleanup2.bin.header", F_OK), 0)
+        << "Header file should have been removed";
+
+    /* Safety cleanup in case test assertions fail */
+    ret = system("rm -f /tmp/testfirmware_cleanup2.bin /tmp/testfirmware_cleanup2.bin.header");
+    global_mockexternal_ptr = NULL;
+    g_DeviceUtilsMock = &Deviceglobal;
+}
+
 TEST(MainHelperFunctionTest,chunkDownloadTestFail2){
     MockExternal mockexternal;
     global_mockexternal_ptr = &mockexternal;

--- a/unittest/basic_rdkv_main_gtest.cpp
+++ b/unittest/basic_rdkv_main_gtest.cpp
@@ -657,12 +657,9 @@ TEST(MainHelperFunctionTest,chunkDownloadgetfilesizeTestFail){
 /* Test: Verify that when getFileSize() returns -1 (error), chunkDownload()
  * cleans up both the partial image file and its .header file via unlink(). */
 TEST(MainHelperFunctionTest,chunkDownloadgetfilesizeFailCleansUpFiles){
-    MockExternal mockexternal;
-    global_mockexternal_ptr = &mockexternal;
     DeviceUtilsMock DeviceMock;
     g_DeviceUtilsMock = &DeviceMock;
     MockExternal mock;
-    g_DeviceUtilsMock = &DeviceMock;
     global_mockexternal_ptr = &mock;
 
     int httpcode = -1;
@@ -697,12 +694,9 @@ TEST(MainHelperFunctionTest,chunkDownloadgetfilesizeFailCleansUpFiles){
 /* Test: Verify that when content_len is 0 (no Content-Length in header)
  * and the partial file is present, chunkDownload() cleans up both files. */
 TEST(MainHelperFunctionTest,chunkDownloadNoContentLenCleansUpFiles){
-    MockExternal mockexternal;
-    global_mockexternal_ptr = &mockexternal;
     DeviceUtilsMock DeviceMock;
     g_DeviceUtilsMock = &DeviceMock;
     MockExternal mock;
-    g_DeviceUtilsMock = &DeviceMock;
     global_mockexternal_ptr = &mock;
 
     int httpcode = -1;

--- a/unittest/fwdl_interface_gtest.cpp
+++ b/unittest/fwdl_interface_gtest.cpp
@@ -175,7 +175,9 @@ TEST_F(InterfaceTestFixture, TestName_isIncremetalCDLEnableSuccess)
 {
     EXPECT_CALL(*g_InterfaceMock, getRFCParameter(_, _, _)).Times(1).WillOnce(Return(1));
     //EXPECT_CALL(*g_InterfaceMock, getDevicePropertyData(_, _, _)).Times(1).WillOnce(Return(0));
-    EXPECT_CALL(*g_InterfaceMock, filePresentCheck(_)).WillOnce(Return(0));
+    EXPECT_CALL(*g_InterfaceMock, filePresentCheck(_)).WillRepeatedly(Return(0));
+    EXPECT_CALL(*g_InterfaceMock, getFileSize(_)).WillOnce(Return(100));
+    EXPECT_CALL(*g_InterfaceMock, getContentLength(_)).WillOnce(Return(1234));
     EXPECT_EQ(isIncremetalCDLEnable("/tmp/123.bin"), 1);
 }
 TEST_F(InterfaceTestFixture, TestName_isIncremetalCDLEnableFailrfc)

--- a/unittest/mocks/interface_mock.cpp
+++ b/unittest/mocks/interface_mock.cpp
@@ -76,7 +76,7 @@ extern "C" size_t getContentLength(const char *file)
         cout << "getContentLength g_InterfaceMock object is NULL" << endl;
         return 0;
     }
-    printf("Inside Mock Function getContentLength\n");
+    printf("Inside Mock Function  getContentLength\n");
     return g_InterfaceMock->getContentLength(file);
 }
 extern "C" int getDevicePropertyData(const char *model, char *data, int size)

--- a/unittest/mocks/interface_mock.cpp
+++ b/unittest/mocks/interface_mock.cpp
@@ -59,6 +59,26 @@ extern "C" int filePresentCheck(const char *filename)
     printf("Inside Mock Function filePresentCheck\n");
     return g_InterfaceMock->filePresentCheck(filename);
 }
+extern "C" int getFileSize(const char *filename)
+{
+    if (!g_InterfaceMock)
+    {
+        cout << "getFileSize g_InterfaceMock object is NULL" << endl;
+        return -1;
+    }
+    printf("Inside Mock Function getFileSize\n");
+    return g_InterfaceMock->getFileSize(filename);
+}
+extern "C" size_t getContentLength(const char *file)
+{
+    if (!g_InterfaceMock)
+    {
+        cout << "getContentLength g_InterfaceMock object is NULL" << endl;
+        return 0;
+    }
+    printf("Inside Mock Function getContentLength\n");
+    return g_InterfaceMock->getContentLength(file);
+}
 extern "C" int getDevicePropertyData(const char *model, char *data, int size)
 {
     if (!g_InterfaceMock)

--- a/unittest/mocks/interface_mock.h
+++ b/unittest/mocks/interface_mock.h
@@ -32,6 +32,8 @@ class FwDlInterface
     public:
         virtual ~FwDlInterface() {}
         virtual int filePresentCheck(const char *filename) = 0;
+        virtual int getFileSize(const char *filename) = 0;
+        virtual size_t getContentLength(const char *file) = 0;
         virtual int getRFCParameter(char* type, const char* key, RFC_ParamData_t *param) = 0;
         virtual int setRFCParameter(char* type, const char* key, const char *value, int datatype) = 0;
         virtual int getDevicePropertyData(const char *model, char *data, int size) = 0;
@@ -55,6 +57,8 @@ class FwDlInterfaceMock: public FwDlInterface
     public:
         virtual ~FwDlInterfaceMock() {}
         MOCK_METHOD(int, filePresentCheck, (const char *filename ), ());
+        MOCK_METHOD(int, getFileSize, (const char *filename ), ());
+        MOCK_METHOD(size_t, getContentLength, (const char *file ), ());
         MOCK_METHOD(int, getRFCParameter, (char* type, const char* key, RFC_ParamData_t *param), ());
         MOCK_METHOD(int, setRFCParameter, (char* type, const char* key, const char *value, int datatype), ());
         MOCK_METHOD(int, getDevicePropertyData, (const char *model, char *data, int size), ());


### PR DESCRIPTION
This pull request improves error handling and cleanup logic during file downloads, particularly for incremental CDL (Chunked Download Loader) scenarios. The changes ensure that incomplete or invalid files and their associated header files are properly removed, preventing potential issues with corrupted downloads. 

**Error handling and cleanup improvements:**

* In `chunkDownload` (`src/chunk.c`), added logic to remove partially downloaded files and their header files if file size retrieval fails or if required conditions for chunk download are not met. This prevents leftover incomplete files.
* In `isIncremetalCDLEnable` (`src/rfcInterface/rfcinterface.c`), enhanced checks to ensure both the main file and its header file are valid before enabling incremental CDL. If validation fails, both files are unlinked (deleted) to avoid using corrupted data. [[1]](diffhunk://#diff-4a2754fb1af148c8627e3e580b12527f6f0c155f3f8f5ef84dd0c4ad7e7df73eR219-R229) [[2]](diffhunk://#diff-4a2754fb1af148c8627e3e580b12527f6f0c155f3f8f5ef84dd0c4ad7e7df73eR242-R254)

**Utility and interface updates:**

* Declared a new function `getContentLength` in the header `rdkv_upgrade.h` for retrieving content length from a file, supporting more robust file validation.
* Included the `rdkv_upgrade.h` header in `rfcinterface.c` to access the new utility function.