### PR TITLE
ES1-3219:[RDKE] CodeBig CDL Failure – Firmware Download Fails with HTTP 000

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -137,6 +137,11 @@ librdksw_jsonparse_includedir = ${includedir}
 librdksw_flash_includedir = ${includedir}
 librdksw_fwutils_includedir = ${includedir}
 
+# Shared/common headers not tied to specific libraries
+include_HEADERS = \
+    ${top_srcdir}/src/rbusInterface/rbusInterface.h \
+    ${top_srcdir}/src/include/device_status_helper.h
+
 bin_PROGRAMS= rdkvfwupgrader
 
 
@@ -150,17 +155,8 @@ rdkvfwupgrader_SOURCES = \
 rdkvfwupgrader_LDADD = librdksw_jsonparse.la librdksw_upgrade.la librdksw_rfcIntf.la librdksw_iarmIntf.la librdksw_flash.la librdksw_fwutils.la $(cjson_LIBS) $(curl_LIBS) -lrdkloggers -ldwnlutil -lfwutils -lsecure_wrapper -lparsejson -lpthread -lrbus
 rdkvfwupgrader_LDFLAGS = -L$(PKG_CONFIG_SYSROOT_DIR)/$(libdir)
 
-rdkvfwupgrader_include_HEADERS = \
-    ${top_srcdir}/src/rbusInterface/rbusInterface.h \
-    ${top_srcdir}/src/include/rfcinterface.h \
-    ${top_srcdir}/src/include/iarmInterface.h \
-    ${top_srcdir}/src/include/device_status_helper.h
-
 rdkvfwupgrader_CFLAGS = -I${top_srcdir}/src/include -I${top_srcdir}/src/deviceutils
 rdkvfwupgrader_CPPFLAGS = -I${top_srcdir}/src/include -I${top_srcdir}/src/deviceutils
-
-
-rdkvfwupgrader_includedir = ${includedir}
 
 if INSTALL_TEST_FWUPGRADER
 bin_PROGRAMS += testrdkvfwupgrader

--- a/src/rdkv_upgrade.c
+++ b/src/rdkv_upgrade.c
@@ -658,8 +658,10 @@ int codebigdownloadFile( int server_type, const char* artifactLocationUrl, const
         } else {
             setDwnlState(RDKV_FWDNLD_DOWNLOAD_INIT);
         }
-        // Use the passed curl handle instead of creating a new one
-        if (curl != NULL && *curl != NULL) {
+		if (curl != NULL) {
+			*curl = doCurlInit();
+		}
+		if (curl != NULL && *curl != NULL) {
             if (server_type == HTTP_XCONF_CODEBIG) {
                 setDwnlState(RDKV_XCONF_FWDNLD_DOWNLOAD_INPROGRESS);
             } else {
@@ -672,8 +674,7 @@ int codebigdownloadFile( int server_type, const char* artifactLocationUrl, const
                 setDwnlState(RDKV_FWDNLD_DOWNLOAD_EXIT);
             }
             doStopDownload(*curl);
-            // Don't set curl = NULL here - preserve the handle for reuse
-            /* Stop the donwload if Throttle speed rfc is set to zero */
+            *curl = NULL;
             if (*force_exit == 1 && (curl_ret_code == 23)) {
                 uninitialize(INITIAL_VALIDATION_SUCCESS);
                 exit(1);


### PR DESCRIPTION
* ES1-3219:[RDKE] CodeBig CDL Failure – Firmware Download Fails with HTTP 000 (ret:-1) After Fallback

* Update rdkv_upgrade.c

* ES1-3219:[RDKE] CodeBig CDL Failure – Firmware Download Fails with HTTP 000 (ret:-1) After Fallback