### PR TITLE
RDKEMW-16887:Daemon failing to start, leading to Initial validation failed

### DIFF
--- a/src/rdkFwupdateMgr.c
+++ b/src/rdkFwupdateMgr.c
@@ -1249,7 +1249,7 @@ int main(int argc, char *argv[]) {
 				     * A previous firmware download+flash already completed
 				     * (/tmp/fw_preparing_to_reboot was present).
 				     * The file has been cleaned up by initialValidation().
-				     * In the daemon model, we transition to IDLE and wait
+				     * In the daemon mode, we transition to IDLE and wait
 				     * for the pending reboot or next D-Bus request.
 				     */
 				    SWLOG_INFO("Software Update already completed (pending reboot). "

--- a/src/rdkFwupdateMgr.c
+++ b/src/rdkFwupdateMgr.c
@@ -1244,32 +1244,40 @@ int main(int argc, char *argv[]) {
 				       }
 				       */
 			    }
+			    else if(init_validate_status == INITIAL_VALIDATION_DWNL_COMPLETED){
+				    /**
+				     * A previous firmware download+flash already completed
+				     * (/tmp/fw_preparing_to_reboot was present).
+				     * The file has been cleaned up by initialValidation().
+				     * In the daemon model, we transition to IDLE and wait
+				     * for the pending reboot or next D-Bus request.
+				     */
+				    SWLOG_INFO("Software Update already completed (pending reboot). "
+						    "Transitioning to IDLE.\n");
+				    if (0 == (strncmp(device_info.maint_status, "true", 4))) {
+					    eventManager("MaintenanceMGR", MAINT_FWDOWNLOAD_COMPLETE);
+				    }
+				    currentState = STATE_IDLE;
+			    }
+			    else if(init_validate_status == INITIAL_VALIDATION_DWNL_INPROGRESS){
+				    /**
+				     * Another instance is currently downloading firmware.
+				     * In the daemon model, transition to IDLE and wait.
+				     * The in-progress download will complete independently.
+				     */
+				    SWLOG_INFO("Firmware download already in progress by another process. "
+						    "Transitioning to IDLE.\n");
+				    if (0 == (strncmp(device_info.maint_status, "true", 4))) {
+					    eventManager("MaintenanceMGR", MAINT_FWDOWNLOAD_INPROGRESS);
+				    }
+				    currentState = STATE_IDLE;
+			    }
 			    else{
-				    SWLOG_ERROR("Initial validation failed\n");
+				    /* INITIAL_VALIDATION_FAIL or unknown status */
+				    SWLOG_ERROR("Initial validation failed (status=%d)\n", init_validate_status);
 				    goto cleanup_and_exit;
 			    }
-			    /*this is for sending the intermediate updates back to apps and */
-			    /*
-				if (init_validate_status == INITIAL_VALIDATION_DWNL_INPROGRESS){
-				if (!(strncmp(device_info.maint_status, "true", 4))) {
-				eventManager("MaintenanceMGR", MAINT_FWDOWNLOAD_INPROGRESS); //Sending status to maintenance manager
-				}
-				}else if(init_validate_status == INITIAL_VALIDATION_DWNL_COMPLETED) {
-				SWLOG_INFO("Software Update is completed by AS/EPG, Exiting from firmware download.\n");
-				}else if ((ret_curl_code != 0) || (json_res != 0)) {
-				if (!(strncmp(device_info.maint_status, "true", 4))) {
-				eventManager("MaintenanceMGR", MAINT_FWDOWNLOAD_ERROR); //Sending status to maintenance manager
-				}
-				if (trigger_type == 6) {
-				unsetStateRed();
-				}
-				}else {
-				if (!(strncmp(device_info.maint_status, "true", 4))) {
-				eventManager("MaintenanceMGR", MAINT_FWDOWNLOAD_COMPLETE); //Sending status to maintenance manager
-				}
-				}
-				*/
-				break;
+			    break;
 		    case STATE_IDLE:
 				/**
 				 * Main operational state - D-Bus event loop.

--- a/src/rdkFwupdateMgr.c
+++ b/src/rdkFwupdateMgr.c
@@ -1249,14 +1249,14 @@ int main(int argc, char *argv[]) {
 				     * A previous firmware download+flash already completed
 				     * (/tmp/fw_preparing_to_reboot was present).
 				     * The file has been cleaned up by initialValidation().
+				     * initialValidation() is also responsible for emitting
+				     * the MAINT_FWDOWNLOAD_COMPLETE event for this case,
+				     * so avoid sending a duplicate notification here.
 				     * In the daemon model, we transition to IDLE and wait
 				     * for the pending reboot or next D-Bus request.
 				     */
 				    SWLOG_INFO("Software Update already completed (pending reboot). "
 						    "Transitioning to IDLE.\n");
-				    if (0 == (strncmp(device_info.maint_status, "true", 4))) {
-					    eventManager("MaintenanceMGR", MAINT_FWDOWNLOAD_COMPLETE);
-				    }
 				    currentState = STATE_IDLE;
 			    }
 			    else if(init_validate_status == INITIAL_VALIDATION_DWNL_INPROGRESS){


### PR DESCRIPTION
This pull request refines the firmware update manager's state handling logic in `src/rdkFwupdateMgr.c`. The main improvement is a more robust and descriptive branching for initial validation outcomes, ensuring the system transitions to the appropriate state and logs clear messages for each scenario. This enhances maintainability and clarity, especially in daemon mode.

**State handling improvements:**

* Added explicit handling for `INITIAL_VALIDATION_DWNL_COMPLETED`, logging the completed state, notifying the maintenance manager if needed, and transitioning to `STATE_IDLE` instead of exiting immediately.
* Added explicit handling for `INITIAL_VALIDATION_DWNL_INPROGRESS`, logging the in-progress state, notifying the maintenance manager, and transitioning to `STATE_IDLE`.
* Retained the error path for failed or unknown validation, but improved the error message to include the status code.

**Code clarity and maintainability:**

* Replaced a large, commented-out block and scattered conditionals with clear, documented branches for each possible validation result.