### PR TITLE
RDKEMW-19691 : Syncing of Gerrit commits that are required for security components

### DIFF
--- a/src/device_status_helper.c
+++ b/src/device_status_helper.c
@@ -345,6 +345,10 @@ void unsetStateRed(void)
     if (ret == 0) {
         SWLOG_INFO("RED:unsetStateRed: Exiting State Red\n");
 	unlink(STATEREDFLAG);
+	int rfc_ret = write_RFCProperty("REDRECV", RFC_RED_RECV, "DISABLED", RFC_STRING);
+	if (rfc_ret == WRITE_RFC_FAILURE) {
+		SWLOG_ERROR("write_RFCProperty() return failed Status %d\n", rfc_ret);
+        }
     } else {
         SWLOG_INFO("RED:unsetStateRed: Not in State Red\n");
     }
@@ -375,6 +379,7 @@ int checkAndEnterStateRed(int curlret, const char *disableStatsUpdate) {
             || (curlret == 91)|| (curlret == 495)) {
         SWLOG_INFO("RED checkAndEnterStateRed: Curl SSL/TLS error %d. Set State Red Recovery Flag and Exit!!!", curlret);
         t2CountNotify("CDLrdkportal_split", curlret);
+	t2CountNotify("RED_STATE_REASON", curlret);
         //CID:280507-Unchecked return value
 	if(remove(DIRECT_BLOCK_FILENAME) != 0){
 		perror("Error deleting DIRECT_BLOCK_FAILURE");

--- a/src/flash.c
+++ b/src/flash.c
@@ -307,6 +307,10 @@ int postFlash(const char *maint, const char *upgrade_file, int upgrade_type, con
     eventManager(IMG_DWL_EVENT, IMAGE_FWDNLD_FLASH_COMPLETE);
     if( isInStateRed() ) {
 	    eventManager(RED_STATE_EVENT, RED_RECOVERY_PROGRAMMED);
+	    int rfc_ret = write_RFCProperty("REDRECV", RFC_RED_RECV, "PROGRAMMED", RFC_STRING);
+	    if (rfc_ret == WRITE_RFC_FAILURE) {
+		    SWLOG_ERROR("write_RFCProperty() return failed Status %d\n", rfc_ret);
+	    }
 	    SWLOG_INFO("Creating red_state_reboot file\n");
 	    fp = fopen(RED_STATE_REBOOT, "w");
 	    if (fp != NULL) {

--- a/src/include/rfcinterface.h
+++ b/src/include/rfcinterface.h
@@ -86,6 +86,7 @@ typedef struct rfcdetails {
 #define RFC_FW_REBOOT_NOTIFY "Device.DeviceInfo.X_RDKCENTRAL-COM_xOpsDeviceMgmt.RPC.RebootPendingNotification"
 #define RFC_FW_AUTO_EXCLUDE "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.FWUpdate.AutoExcluded.Enable"
 #define RFC_DEBUGSRV "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Identity.DbgServices.Enable"
+#define RFC_RED_RECV "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.RedRecovery.Status"
 
 #define RFC_XCONF_CHECK_NOW "Device.X_COMCAST-COM_Xcalibur.Client.xconfCheckNow"
 

--- a/src/rdkv_main.c
+++ b/src/rdkv_main.c
@@ -866,6 +866,10 @@ static int MakeXconfComms( XCONFRES *pResponse, int server_type, int *pHttp_code
                         if( (filePresentCheck( RED_STATE_REBOOT ) == RDK_API_SUCCESS) ) {
                              SWLOG_INFO("%s : RED Recovery completed\n", __FUNCTION__);
                              eventManager(RED_STATE_EVENT, RED_RECOVERY_COMPLETED);
+			     int rfc_ret = write_RFCProperty("REDRECV", RFC_RED_RECV, "COMPLETED", RFC_STRING);
+			     if (rfc_ret == WRITE_RFC_FAILURE) {
+				     SWLOG_ERROR("write_RFCProperty() return failed Status %d\n", rfc_ret);
+			     }
                              unlink(RED_STATE_REBOOT);
                         }
                     }
@@ -1144,6 +1148,10 @@ int main(int argc, char *argv[]) {
         eventManager(FW_STATE_EVENT, FW_STATE_UNINITIALIZED);
 	if( isInStateRed() ) {
           eventManager(RED_STATE_EVENT, RED_RECOVERY_STARTED);
+	  int rfc_ret = write_RFCProperty("REDRECV", RFC_RED_RECV, "STARTED", RFC_STRING);
+	  if (rfc_ret == WRITE_RFC_FAILURE) {
+		  SWLOG_ERROR("write_RFCProperty() return failed Status %d\n", rfc_ret);
+	  }
         }
 	eventManager(FW_STATE_EVENT, FW_STATE_REQUESTING);
         ret_curl_code = MakeXconfComms( &response, server_type, &http_code );

--- a/src/rdkv_upgrade.c
+++ b/src/rdkv_upgrade.c
@@ -618,6 +618,10 @@ int rdkv_upgrade_request(const RdkUpgradeContext_t* context, void** curl, int* p
 	    if( isInStateRed() ) {
                  SWLOG_INFO("RED recovery download complete\n");
                  eventManager(RED_STATE_EVENT, RED_RECOVERY_DOWNLOADED);
+		 int rfc_ret = write_RFCProperty("REDRECV", RFC_RED_RECV, "DOWNLOADED", RFC_STRING);
+		 if (rfc_ret == WRITE_RFC_FAILURE) {
+			 SWLOG_ERROR("write_RFCProperty() return failed Status %d\n", rfc_ret);
+		 }
             }
             SWLOG_INFO("Downloaded %s of size %d\n", dwlpath_filename, getFileSize(dwlpath_filename));
             Upgradet2CountNotify("Filesize_split", getFileSize(dwlpath_filename));

--- a/unittest/mocks/deviceutils_mock.cpp
+++ b/unittest/mocks/deviceutils_mock.cpp
@@ -144,6 +144,17 @@ extern "C" int read_RFCProperty(char* type, const char* key, char *out_value, si
     return g_DeviceUtilsMock->read_RFCProperty(type, key, out_value, datasize);
 }
 
+extern "C" int write_RFCProperty(char* type, const char* key, const char *value, RFCVALDATATYPE datatype)
+{
+    if (!g_DeviceUtilsMock)
+    {
+        cout << "write_RFCProperty g_DeviceUtilsMock object is NULL" << endl;
+        return -1;
+    }
+    printf("Inside Mock Function write_RFCProperty\n");
+    return g_DeviceUtilsMock->write_RFCProperty(type, key, value, datatype);
+}
+
 extern "C" int filePresentCheck(const char *filename)
 {
     if (!g_DeviceUtilsMock)

--- a/unittest/mocks/deviceutils_mock.h
+++ b/unittest/mocks/deviceutils_mock.h
@@ -25,6 +25,18 @@
 //#include "rdk_fwdl_utils.h"  // For BUILDTYPE enum
 #define RDK_API_SUCCESS 0
 
+/* RFCVALDATATYPE is defined in rfcinterface.h. Include it here inside an
+ * extern "C" block so that the C symbols use C linkage in C++ tests and
+ * we avoid duplicating the typedef, which can cause redefinition errors
+ * when include order varies. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "rfcinterface.h"
+#ifdef __cplusplus
+}
+#endif
+
 class DeviceUtilsInterface
 {
     public:
@@ -37,6 +49,7 @@ class DeviceUtilsInterface
 	virtual int getJsonRpcData(void *Curl_req, FileDwnl_t *req_data, char token_header, int httpCode ) = 0;
 	virtual int getDevicePropertyData(const char *model, char *data, int size) = 0;
 	virtual int read_RFCProperty(char* type, const char* key, char *out_value, size_t datasize) = 0;
+	virtual int write_RFCProperty(char* type, const char* key, const char *value, RFCVALDATATYPE datatype) = 0;
 	virtual int filePresentCheck(const char *filename) = 0;
 	virtual int getFileSize(const char *filename) = 0;
 	virtual bool isInStateRed() = 0;
@@ -59,6 +72,7 @@ class DeviceUtilsMock: public DeviceUtilsInterface
 	MOCK_METHOD(int, getJsonRpcData, (void *Curl_req, FileDwnl_t *req_data, char token_header, int httpCode ), ());
 	MOCK_METHOD(int, getDevicePropertyData, (const char *model, char *data, int size), ());
 	MOCK_METHOD(int, read_RFCProperty, (char* type, const char* key, char *out_value, size_t datasize), ());
+	MOCK_METHOD(int, write_RFCProperty, (char* type, const char* key, const char *value, RFCVALDATATYPE datatype), ());
 	MOCK_METHOD(int, filePresentCheck, (const char *filename ), ());
 	MOCK_METHOD(int, getFileSize, (const char *filename ), ());
 	MOCK_METHOD(bool, isInStateRed, (), ());


### PR DESCRIPTION
RDK-55195: Notify the RED status events

Reason for change: Notify the RED state events to T2
Test Procedure: Check working of FW upgrade
Risks: Low
