### PR TITLE
RDKEMW-20374:[Llama G2][RDK E][8.5] : Dual instances of rdkvfwupgrader runs when device is in state red

### DIFF
--- a/src/device_status_helper.c
+++ b/src/device_status_helper.c
@@ -28,6 +28,7 @@
 #include "download_status_helper.h"
 #include "json_process.h"
 #include "device_api.h"
+#include "rdkv_upgrade.h"
 #ifndef GTEST_ENABLE
 #include "common_device_api.h"
 #endif
@@ -355,14 +356,13 @@ void unsetStateRed(void)
 }
 
 
-/* Description: If state red support is present eneter to state red
+/* Description: If state red support is present detect state red condition
  * @param curlret: Receving curl status from Caller
  * @return: 0 on success (no state red entry needed or flag already set)
- *         -1 on TLS/SSL error (state red entered, process should terminate in CLI mode)
+ *         RDKV_UPGRADE_ERROR_STATE_RED (-102) on TLS/SSL error detected
  * */
 int checkAndEnterStateRed(int curlret, const char *disableStatsUpdate) {
     int ret = -1;
-    FILE *fp = NULL;
     struct FWDownloadStatus fwdls;
     ret = isStateRedSupported();
     if(ret == 0) {
@@ -407,13 +407,11 @@ int checkAndEnterStateRed(int curlret, const char *disableStatsUpdate) {
         //TODO sprintf(fwdls.DelayDownload, "DelayDownload|%s\n", delaydnld); // This data should come from script as a argument
         updateFWDownloadStatus(&fwdls, disableStatsUpdate);
 
-        uninitialize(INITIAL_VALIDATION_SUCCESS);
-        fp = fopen(STATEREDFLAG, "w");
-        if(fp != NULL) {
-            fclose(fp);
-        }
+        SWLOG_INFO("Deleting DIFD.pid file for state-red recovery\n");
+        unlink(DIFDPID);
+
         SWLOG_ERROR("RED checkAndEnterStateRed: State red entered due to TLS/SSL error %d. Returning error to caller.\n", curlret);
-        return -1;
+        return RDKV_UPGRADE_ERROR_STATE_RED;
     } else {
         //Recovery completed event send for the failure case but not due to fatal error
         if( (filePresentCheck( RED_STATE_REBOOT ) == RDK_API_SUCCESS) ) {

--- a/src/include/rdkv_upgrade.h
+++ b/src/include/rdkv_upgrade.h
@@ -39,6 +39,7 @@ typedef enum {
     RDKV_UPGRADE_SUCCESS = 0,
     RDKV_UPGRADE_ERROR_THROTTLE_ZERO = -100,  // Throttle speed = 0
     RDKV_UPGRADE_ERROR_FORCE_EXIT = -101,      // Force exit (curl 23)
+    RDKV_UPGRADE_ERROR_STATE_RED = -102,       // State red recovery (TLS/SSL fatal)
 } rdkv_upgrade_error_t;
 
 /**
@@ -137,7 +138,7 @@ int fallBack(
 );
 
 
-void dwnlError(int curl_code, int http_code, int server_type,const DeviceProperty_t *device_info,const char *lastrun, char *disableStatsUpdate);
+int dwnlError(int curl_code, int http_code, int server_type,const DeviceProperty_t *device_info,const char *lastrun, char *disableStatsUpdate);
 
 void saveHTTPCode(int http_code, const char *lastrun);
 void Upgradet2CountNotify(char *marker, int val); 

--- a/src/rdkv_main.c
+++ b/src/rdkv_main.c
@@ -657,6 +657,9 @@ int checkTriggerUpgrade(XCONFRES *pResponse, const char *model)
             SWLOG_ERROR("%s: PCI upgrade failed with library error: %s (code: %d)\n",
                        __FUNCTION__, rdkv_upgrade_strerror(pci_curl_code), pci_curl_code);
             
+            if (pci_curl_code == RDKV_UPGRADE_ERROR_STATE_RED) {
+                return RDKV_UPGRADE_ERROR_STATE_RED;
+            }
             // CLI binary can exit on fatal library errors
             if (pci_curl_code == RDKV_UPGRADE_ERROR_THROTTLE_ZERO || 
                 pci_curl_code == RDKV_UPGRADE_ERROR_FORCE_EXIT) {
@@ -713,6 +716,9 @@ int checkTriggerUpgrade(XCONFRES *pResponse, const char *model)
                 SWLOG_ERROR("%s: PDRI upgrade failed with library error: %s (code: %d)\n",
                            __FUNCTION__, rdkv_upgrade_strerror(pdri_curl_code), pdri_curl_code);
                 
+                if (pdri_curl_code == RDKV_UPGRADE_ERROR_STATE_RED) {
+                    return RDKV_UPGRADE_ERROR_STATE_RED;
+                }
                 // CLI binary can exit on fatal library errors
                 if (pdri_curl_code == RDKV_UPGRADE_ERROR_THROTTLE_ZERO || 
                     pdri_curl_code == RDKV_UPGRADE_ERROR_FORCE_EXIT) {
@@ -1200,6 +1206,14 @@ int main(int argc, char *argv[]) {
     }else {
         if (!(strncmp(device_info.maint_status, "true", 4))) {
             eventManager("MaintenanceMGR", MAINT_FWDOWNLOAD_COMPLETE); //Sending status to maintenance manager
+        }
+    }
+
+    /* State-red: create flag for recovery script before process cleanup */
+    if (ret_curl_code == RDKV_UPGRADE_ERROR_STATE_RED) {
+        FILE *fp_sr = fopen(STATEREDFLAG, "w");
+        if (fp_sr != NULL) {
+            fclose(fp_sr);
         }
     }
 

--- a/src/rdkv_upgrade.c
+++ b/src/rdkv_upgrade.c
@@ -46,6 +46,8 @@ const char* rdkv_upgrade_strerror(int error) {
             return "Throttle speed set to 0 - download blocked";
         case RDKV_UPGRADE_ERROR_FORCE_EXIT:
             return "Force exit requested (curl error 23)";
+        case RDKV_UPGRADE_ERROR_STATE_RED:
+            return "State red recovery (TLS/SSL fatal error)";
         default:
             if (error > 0) {
                 return "CURL error"; // Existing CURL error codes
@@ -118,19 +120,20 @@ bool checkForTlsErrors(int curl_code, const char *type)
 /* Description:Use for store download error and send telemetry
  * @param: curl_code : curl return status
  * @param: http_code : http return status
- * @return void:
+ * @return int: RDKV_UPGRADE_ERROR_STATE_RED if state-red entered, 0 otherwise
  * */
-void dwnlError(int curl_code, int http_code, int server_type,const DeviceProperty_t *device_info,const char *lastrun,char *disableStatsUpdate)
+int dwnlError(int curl_code, int http_code, int server_type,const DeviceProperty_t *device_info,const char *lastrun,char *disableStatsUpdate)
 {
     char telemetry_data[32];
     char device_type[32];
     struct FWDownloadStatus fwdls;
     char failureReason[128];
     char *type = "Direct"; //TODO: Need to pass this type as a function parameter
+    int state_red_ret = 0;
 
     if (device_info == NULL) {
         SWLOG_ERROR("%s: device_info parameter is NULL\n", __FUNCTION__);
-        return;
+        return 0;
     }
 
     *failureReason = 0;
@@ -188,7 +191,7 @@ void dwnlError(int curl_code, int http_code, int server_type,const DevicePropert
         snprintf(fwdls.dnldVersn, sizeof(fwdls.dnldVersn), "DnldVersn|\n");
         snprintf(fwdls.dnldfile, sizeof(fwdls.dnldfile), "DnldFile|\n");
         snprintf(fwdls.dnldurl, sizeof(fwdls.dnldurl), "DnldURL|\n");
-        snprintf(fwdls.lastrun, sizeof(fwdls.lastrun), "LastRun|%s\n", lastrun); // lastrun his data should come from script as a argument
+        snprintf(fwdls.lastrun, sizeof(fwdls.lastrun), "LastRun|%s\n", lastrun != NULL ? lastrun : ""); // lastrun his data should come from script as a argument
         snprintf(fwdls.FwUpdateState, sizeof(fwdls.FwUpdateState), "FwUpdateState|Failed\n");
         snprintf(fwdls.DelayDownload, sizeof(fwdls.DelayDownload), "DelayDownload|\n"); // This data should come from script as a argument
         updateFWDownloadStatus(&fwdls, disableStatsUpdate);
@@ -196,15 +199,22 @@ void dwnlError(int curl_code, int http_code, int server_type,const DevicePropert
     // HTTP CODE 495 - Expired client certificate not in servers allow list
     if( http_code == 495 ) {
         SWLOG_INFO("%s : Calling checkAndEnterStateRed() with code:%d\n", __FUNCTION__, http_code);
-        if (checkAndEnterStateRed(http_code, disableStatsUpdate) != 0) {
+        state_red_ret = checkAndEnterStateRed(http_code, disableStatsUpdate);
+        if (state_red_ret != 0) {
             SWLOG_ERROR("%s : State red entered due to HTTP error %d\n", __FUNCTION__, http_code);
         }
     }else {
         SWLOG_INFO("%s : Calling checkAndEnterStateRed() with code:%d\n", __FUNCTION__, curl_code);
-        if (checkAndEnterStateRed(curl_code, disableStatsUpdate) != 0) {
+        state_red_ret = checkAndEnterStateRed(curl_code, disableStatsUpdate);
+        if (state_red_ret != 0) {
             SWLOG_ERROR("%s : State red entered due to curl error %d\n", __FUNCTION__, curl_code);
         }
     }
+    /* Safety net: if flag was set by a prior call or external mechanism */
+    if (state_red_ret == 0 && isInStateRed() == 1) {
+        state_red_ret = RDKV_UPGRADE_ERROR_STATE_RED;
+    }
+    return state_red_ret;
 }
 
 /* Description: Save http value inside file
@@ -513,6 +523,9 @@ int rdkv_upgrade_request(const RdkUpgradeContext_t* context, void** curl, int* p
 	    else if (ret_curl_code == RDKV_UPGRADE_ERROR_FORCE_EXIT) {
 		    return RDKV_UPGRADE_ERROR_FORCE_EXIT;
 	    }
+	    else if (ret_curl_code == RDKV_UPGRADE_ERROR_STATE_RED) {
+		    return RDKV_UPGRADE_ERROR_STATE_RED;
+	    }
 
             if (ret_curl_code != CURL_SUCCESS ||
                 (*pHttp_code != HTTP_SUCCESS && *pHttp_code != HTTP_CHUNK_SUCCESS && *pHttp_code != HTTP_PAGE_NOT_FOUND)) {
@@ -543,6 +556,9 @@ int rdkv_upgrade_request(const RdkUpgradeContext_t* context, void** curl, int* p
             }
             else if (ret_curl_code == RDKV_UPGRADE_ERROR_FORCE_EXIT) {
                     return RDKV_UPGRADE_ERROR_FORCE_EXIT;
+            }
+            else if (ret_curl_code == RDKV_UPGRADE_ERROR_STATE_RED) {
+                    return RDKV_UPGRADE_ERROR_STATE_RED;
             }
             if (ret_curl_code != CURL_SUCCESS ||
                 (*pHttp_code != HTTP_SUCCESS && *pHttp_code != HTTP_CHUNK_SUCCESS && *pHttp_code != HTTP_PAGE_NOT_FOUND)) {
@@ -1166,7 +1182,10 @@ int downloadFile(
     }else {
         SWLOG_ERROR("%s : Direct Image upgrade Fail: curl ret:%d http_code:%d\n", __FUNCTION__, curl_ret_code, *httpCode);
         (server_type == HTTP_SSR_DIRECT) ? setDwnlState(RDKV_FWDNLD_DOWNLOAD_FAILED) : setDwnlState(RDKV_XCONF_FWDNLD_DOWNLOAD_FAILED);
-        dwnlError(curl_ret_code, *httpCode, server_type,device_info,lastrun,disableStatsUpdate);
+        int state_red_ret = dwnlError(curl_ret_code, *httpCode, server_type,device_info,lastrun,disableStatsUpdate);
+        if (state_red_ret == RDKV_UPGRADE_ERROR_STATE_RED) {
+            return RDKV_UPGRADE_ERROR_STATE_RED;
+        }
         if( *(file_dwnl.pathname) != 0 )
         {
             unlink(file_dwnl.pathname);
@@ -1239,6 +1258,8 @@ int retryDownload(
                 break;
             } else if(curl_ret_code == DWNL_BLOCK) {
                 break;
+            } else if(curl_ret_code == RDKV_UPGRADE_ERROR_STATE_RED) {
+                break;
             } else {
                 (server_type == HTTP_SSR_DIRECT) ? SWLOG_INFO("%s : Direct Image upgrade return: retry=%d ret:%d http_code:%d\n", __FUNCTION__, retry_completed, curl_ret_code, *httpCode) : SWLOG_INFO("%s : Direct Image upgrade connection return: retry=%d ret:%d http_code:%d\n", __FUNCTION__, retry_completed, curl_ret_code, *httpCode);
             }
@@ -1302,6 +1323,9 @@ int fallBack(
     if (server_type == HTTP_SSR_DIRECT || server_type == HTTP_XCONF_DIRECT) {
         SWLOG_INFO("%s: calling downloadFile\n", __FUNCTION__ );
         curl_ret_code = downloadFile(context, httpCode, curl);
+        if (curl_ret_code == RDKV_UPGRADE_ERROR_STATE_RED) {
+            return RDKV_UPGRADE_ERROR_STATE_RED;
+        }
         if (*httpCode != HTTP_SUCCESS && *httpCode != HTTP_CHUNK_SUCCESS && *httpCode != 404) {
             SWLOG_ERROR("%s : Direct image upgrade failover request failed return=%d, httpcode=%d\n", __FUNCTION__, curl_ret_code, *httpCode);
         } else {
@@ -1316,6 +1340,9 @@ int fallBack(
         }
         else if (curl_ret_code == RDKV_UPGRADE_ERROR_FORCE_EXIT) {
                 return RDKV_UPGRADE_ERROR_FORCE_EXIT;
+         }
+        else if (curl_ret_code == RDKV_UPGRADE_ERROR_STATE_RED) {
+                return RDKV_UPGRADE_ERROR_STATE_RED;
          }
         if ((curl_ret_code == CURL_SUCCESS) && (*httpCode == HTTP_SUCCESS || *httpCode == HTTP_CHUNK_SUCCESS)) {
             SWLOG_INFO("%s : Codebig Image upgrade Success: ret=%d httpcode=%d\n", __FUNCTION__, curl_ret_code, *httpCode);

--- a/src/rdkv_upgrade.c
+++ b/src/rdkv_upgrade.c
@@ -1058,10 +1058,11 @@ int downloadFile(
         if (ret == MTLS_CERT_FETCH_FAILURE) {
             SWLOG_ERROR("%s : ret=%d\n", __FUNCTION__, ret);
             SWLOG_ERROR("%s : All MTLS certs are failed. Falling back to state red.\n", __FUNCTION__);
-            if (checkAndEnterStateRed(CURL_MTLS_LOCAL_CERTPROBLEM, disableStatsUpdate) != 0) {
+            int mtls_state_red = checkAndEnterStateRed(CURL_MTLS_LOCAL_CERTPROBLEM, disableStatsUpdate);
+            if (mtls_state_red != 0) {
                 SWLOG_ERROR("%s : State red entered due to MTLS cert problem\n", __FUNCTION__);
             }
-            return curl_ret_code;
+            return (mtls_state_red == RDKV_UPGRADE_ERROR_STATE_RED) ? RDKV_UPGRADE_ERROR_STATE_RED : curl_ret_code;
         } else if (ret == STATE_RED_CERT_FETCH_FAILURE) {
             SWLOG_ERROR("%s : State red cert failed.\n", __FUNCTION__);
             return curl_ret_code;

--- a/unittest/basic_rdkv_main_gtest.cpp
+++ b/unittest/basic_rdkv_main_gtest.cpp
@@ -86,7 +86,7 @@ extern "C" {
     int doCurlPutRequest(void *in_curl, FileDwnl_t *pfile_dwnl, char *jsonrpc_auth_token, int *out_httpCode);
     int getOPTOUTValue(const char *filename);
     void getPidStore(const char *key, const char *value);
-    void dwnlError(int curl_code, int http_code, int server_type, const DeviceProperty_t *device_info, const char *lastrun, char *disableStatsUpdate);
+    int dwnlError(int curl_code, int http_code, int server_type, const DeviceProperty_t *device_info, const char *lastrun, char *disableStatsUpdate);
     int peripheral_firmware_dndl(char *pCloudFWLocation, char *pPeripheralFirmwares);
     int fallBack(const RdkUpgradeContext_t* context, int *httpCode, void **curl);
     void saveHTTPCode(int http_code, const char *lastrun);
@@ -441,6 +441,7 @@ TEST(MainHelperFunctionTest, retryDownloadtest8){
 }
 
 TEST(DwnlErrorTest, HandlesCurlCode0) {
+    g_DeviceUtilsMock = nullptr;
     int curl_code = 0;
     int http_code = 200;
     int server_type = 0;
@@ -455,6 +456,7 @@ TEST(DwnlErrorTest, HandlesCurlCode0) {
 }
 
 TEST(DwnlErrorTest, HandlesCurlCode22) {
+    g_DeviceUtilsMock = nullptr;
     int curl_code = 22;
     int http_code = 200;
     int server_type = 0;
@@ -471,6 +473,7 @@ TEST(DwnlErrorTest, HandlesCurlCode22) {
 }
 
 TEST(DwnlErrorTest, HandlesCurlCode18) {
+    g_DeviceUtilsMock = nullptr;
     int curl_code = 18;
     int http_code = 0;
     int server_type = 0;
@@ -488,6 +491,7 @@ TEST(DwnlErrorTest, HandlesCurlCode18) {
 }
 
 TEST(DwnlErrorTest, HandlesCurlCode91) {
+    g_DeviceUtilsMock = nullptr;
     int curl_code = 91;
     int http_code = 200;
     int server_type = 0;


### PR DESCRIPTION
This pull request introduces a new explicit error code and handling for "state red" recovery scenarios triggered by TLS/SSL fatal errors during device upgrade operations. The changes ensure that when a state red condition is detected, the process returns a specific error code, sets recovery flags, and prevents further upgrade attempts until recovery. Several functions are updated to propagate and handle this new error code, and test cases are adjusted accordingly.

**State Red Recovery Handling:**

* Introduced a new error code `RDKV_UPGRADE_ERROR_STATE_RED` (`-102`) in `rdkv_upgrade.h` to represent state red recovery due to TLS/SSL fatal errors.
* Updated `checkAndEnterStateRed`, `dwnlError`, and related functions to return and propagate `RDKV_UPGRADE_ERROR_STATE_RED` when a state red condition is detected, and to set the appropriate recovery flag file. [[1]](diffhunk://#diff-4c4d20d7beeb1ab07f8d9d01e5b9888c4f23997cdec68521517ff8996260b071L358-L365) [[2]](diffhunk://#diff-4c4d20d7beeb1ab07f8d9d01e5b9888c4f23997cdec68521517ff8996260b071L410-R414) [[3]](diffhunk://#diff-7e3e81dbccf35575429d216bf47abd5fa08fdf5ff24794b9ecaa4028e7787189L121-R136) [[4]](diffhunk://#diff-7e3e81dbccf35575429d216bf47abd5fa08fdf5ff24794b9ecaa4028e7787189L191-R217) [[5]](diffhunk://#diff-7e3e81dbccf35575429d216bf47abd5fa08fdf5ff24794b9ecaa4028e7787189L1169-R1189) [[6]](diffhunk://#diff-7e3e81dbccf35575429d216bf47abd5fa08fdf5ff24794b9ecaa4028e7787189L1045-R1065) [[7]](diffhunk://#diff-7e3e81dbccf35575429d216bf47abd5fa08fdf5ff24794b9ecaa4028e7787189R1262-R1263) [[8]](diffhunk://#diff-7e3e81dbccf35575429d216bf47abd5fa08fdf5ff24794b9ecaa4028e7787189R1327-R1329) [[9]](diffhunk://#diff-7e3e81dbccf35575429d216bf47abd5fa08fdf5ff24794b9ecaa4028e7787189R1345-R1347)
* Modified the main process (`rdkv_main.c`) to check for the state red error code and create the recovery flag before cleanup and exit.

**Error Propagation and Handling:**

* Updated all relevant upgrade and fallback logic to check for and propagate `RDKV_UPGRADE_ERROR_STATE_RED`, ensuring the process halts further attempts and returns the correct status. [[1]](diffhunk://#diff-ce4fba6cfc205fc4fd3d494e46fcbda747626839dd66b59e498197cdb8b38075R660-R662) [[2]](diffhunk://#diff-ce4fba6cfc205fc4fd3d494e46fcbda747626839dd66b59e498197cdb8b38075R719-R721) [[3]](diffhunk://#diff-7e3e81dbccf35575429d216bf47abd5fa08fdf5ff24794b9ecaa4028e7787189R526-R528) [[4]](diffhunk://#diff-7e3e81dbccf35575429d216bf47abd5fa08fdf5ff24794b9ecaa4028e7787189R560-R562)
* Enhanced error string reporting to include a message for the new state red error code.

**API and Test Adjustments:**

* Changed the signature of `dwnlError` to return an `int` (the error code), updated all declarations and test usages accordingly. [[1]](diffhunk://#diff-83a973e2e17e5fcaee78c9398ed4c09d1d7a79b088deb871e6cbb2d22d082450L140-R141) [[2]](diffhunk://#diff-6da3a493519663172652d723f5e1ff6bbcde401ae1e2d070a1bfcdc329b45775L89-R89)
* Updated unit tests to match the new function signature and ensure proper initialization. [[1]](diffhunk://#diff-6da3a493519663172652d723f5e1ff6bbcde401ae1e2d070a1bfcdc329b45775R444) [[2]](diffhunk://#diff-6da3a493519663172652d723f5e1ff6bbcde401ae1e2d070a1bfcdc329b45775R459) [[3]](diffhunk://#diff-6da3a493519663172652d723f5e1ff6bbcde401ae1e2d070a1bfcdc329b45775R476) [[4]](diffhunk://#diff-6da3a493519663172652d723f5e1ff6bbcde401ae1e2d070a1bfcdc329b45775R494)

**Code Robustness:**

* Added null checks and safety nets in error handling paths to ensure the state red condition is reliably detected and flagged, even if triggered by external mechanisms.

**Include and Comment Updates:**

* Added missing header includes and improved comments to clarify the new state red handling logic. [[1]](diffhunk://#diff-4c4d20d7beeb1ab07f8d9d01e5b9888c4f23997cdec68521517ff8996260b071R31) [[2]](diffhunk://#diff-4c4d20d7beeb1ab07f8d9d01e5b9888c4f23997cdec68521517ff8996260b071L358-L365)

These changes collectively improve the robustness of the upgrade process in the face of fatal TLS/SSL errors, ensuring the system enters a safe recovery state and prevents repeated failed attempts.…